### PR TITLE
ci: Fix for breaking `upload-artifact` v4.4.0

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -50,12 +50,14 @@ jobs:
         with:
           name: api
           path: "./Server/artifacts/api"
+          include-hidden-files: true
 
       - name: Save Functions
         uses: actions/upload-artifact@v4
         with:
           name: fns
           path: "./Server/artifacts/fns"
+          include-hidden-files: true
 
   build-website:
     runs-on: ubuntu-latest
@@ -103,6 +105,7 @@ jobs:
       with:
         name: web
         path: Client/dist/app/browser
+        include-hidden-files: true
 
   deploy:
     needs: [ "build-backend", "build-website" ]


### PR DESCRIPTION
Breaking change from [upload-artifact](https://github.com/actions/upload-artifact) v4.4.0 that now requires explicit need to place `include-hidden-files: true` under `with:` block.