### PR TITLE
refactor: Breakdown modules

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/router": "18.2.6",
         "@angular/service-worker": "18.2.6",
         "@ctrl/tinycolor": "4.1.0",
-        "@ng-matero/extensions": "18.2.1",
+        "@ng-matero/extensions": "18.2.2",
         "chart.js": "4.4.4",
         "chartjs-adapter-date-fns": "3.0.0",
         "chartjs-plugin-annotation": "3.0.1",
@@ -1779,9 +1779,9 @@
       ]
     },
     "node_modules/@ng-matero/extensions": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/@ng-matero/extensions/-/extensions-18.2.1.tgz",
-      "integrity": "sha512-UdxH5cmkN0S4OxubXIbTvBzwo9JQCm869MkA2oQrZx4MQ85P+pZy1VCdlmPoqIoHkY+rki/R1YVUbayvOIlzWA==",
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@ng-matero/extensions/-/extensions-18.2.2.tgz",
+      "integrity": "sha512-d8q1sFtUvqSXiv9XVBd2a5ET06qaxIKeWjuL8V0SfFdMJLPCwevLmRzWnQGWSocYavD+xIR1oyioMAXkZfpKfw==",
       "license": "MIT",
       "dependencies": {
         "@ng-select/ng-select": "^13.7.0",

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "18.2.6",
     "@angular/service-worker": "18.2.6",
     "@ctrl/tinycolor": "4.1.0",
-    "@ng-matero/extensions": "18.2.1",
+    "@ng-matero/extensions": "18.2.2",
     "chart.js": "4.4.4",
     "chartjs-adapter-date-fns": "3.0.0",
     "chartjs-plugin-annotation": "3.0.1",

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -1,21 +1,10 @@
 import { NgModule } from '@angular/core';
-import { BrowserModule,  } from '@angular/platform-browser';
+import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-
-import {
-  provideHttpClient,
-  withInterceptorsFromDi
-} from '@angular/common/http';
-
-import {
-  ErrorStateMatcher,
-  ShowOnDirtyErrorStateMatcher
-} from '@angular/material/core';
 
 import { MatToolbarModule } from '@angular/material/toolbar';
 
 // services (global)
-import { ApiService } from './services/api.service';
 import { UserService } from './services/user.service';
 import { UtilityService } from './services/utility.service';
 
@@ -40,13 +29,6 @@ import { AppRoutingModule } from './app-routing.module';
     AppRoutingModule
   ],
   providers: [
-    ApiService,
-    {
-      provide: ErrorStateMatcher,
-      useClass: ShowOnDirtyErrorStateMatcher
-    },
-    provideHttpClient(withInterceptorsFromDi()),
-
     UserService,
     UtilityService
   ],

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -4,10 +4,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { MatToolbarModule } from '@angular/material/toolbar';
 
-// services (global)
-import { UserService } from './services/user.service';
-import { UtilityService } from './services/utility.service';
-
 // component
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -28,10 +24,7 @@ import { AppRoutingModule } from './app-routing.module';
     // Application
     AppRoutingModule
   ],
-  providers: [
-    UserService,
-    UtilityService
-  ],
+  providers: [],
   bootstrap: [
     AppComponent
   ]

--- a/client/src/app/components/picker/settings.module.ts
+++ b/client/src/app/components/picker/settings.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 
-import { CommonModule } from '@angular/common';
+import { NgIf, NgFor, NgStyle } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
 import { MatButtonModule } from '@angular/material/button';
@@ -33,7 +33,7 @@ import { PickConfigComponent } from './pick-config.component';
   ],
   bootstrap: [],
   imports: [
-    CommonModule,
+    NgIf, NgFor, NgStyle,
     FormsModule,
     MatButtonModule,
     MatCheckboxModule,

--- a/client/src/app/pages/chart/chart.module.ts
+++ b/client/src/app/pages/chart/chart.module.ts
@@ -1,5 +1,15 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { NgIf } from '@angular/common';
+
+import {
+  provideHttpClient,
+  withInterceptorsFromDi
+} from '@angular/common/http';
+
+import {
+  ErrorStateMatcher,
+  ShowOnDirtyErrorStateMatcher
+} from '@angular/material/core';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -8,6 +18,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 // services
+import { ApiService } from '../../services/api.service';
 import { ChartService } from '../../services/chart.service';
 import { ChartConfigService } from '../../services/config.service';
 
@@ -26,7 +37,7 @@ import { ChartRoutingModule } from './chart-routing.module';
     ChartComponent
   ],
   imports: [
-    CommonModule,
+    NgIf,
     ChartRoutingModule,
     MatButtonModule,
     MatDialogModule,
@@ -35,6 +46,12 @@ import { ChartRoutingModule } from './chart-routing.module';
     MatTooltipModule
   ],
   providers: [
+    ApiService,
+    {
+      provide: ErrorStateMatcher,
+      useClass: ShowOnDirtyErrorStateMatcher
+    },
+    provideHttpClient(withInterceptorsFromDi()),
     ChartService,
     ChartConfigService
   ]

--- a/client/src/app/pages/chart/chart.module.ts
+++ b/client/src/app/pages/chart/chart.module.ts
@@ -20,7 +20,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 // services
 import { ApiService } from '../../services/api.service';
 import { ChartService } from '../../services/chart.service';
-import { ChartConfigService } from '../../services/config.service';
 
 // component
 import { ChartComponent } from './chart.component';
@@ -52,8 +51,7 @@ import { ChartRoutingModule } from './chart-routing.module';
       useClass: ShowOnDirtyErrorStateMatcher
     },
     provideHttpClient(withInterceptorsFromDi()),
-    ChartService,
-    ChartConfigService
+    ChartService
   ]
 })
 export class ChartModule { }

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -4,15 +4,8 @@ import { Observable } from 'rxjs/internal/Observable';
 import { env } from '../../environments/environment';
 
 import {
-  ChartDataset,
-  ScatterDataPoint
-} from 'chart.js';
-
-import {
   IndicatorListing,
   IndicatorParam,
-  IndicatorResult,
-  IndicatorResultConfig,
   IndicatorSelection
 } from '../pages/chart/chart.models';
 

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -9,7 +9,9 @@ import {
   IndicatorSelection
 } from '../pages/chart/chart.models';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class ApiService {
 
   constructor(

--- a/client/src/app/services/chart.service.ts
+++ b/client/src/app/services/chart.service.ts
@@ -71,7 +71,9 @@ import { ApiService } from './api.service';
 import { ChartConfigService } from './config.service';
 import { UtilityService } from './utility.service';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class ChartService {
 
   listings: IndicatorListing[] = [];

--- a/client/src/app/services/chart.service.ts
+++ b/client/src/app/services/chart.service.ts
@@ -3,9 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/internal/Observable';
 
 import {
-  BarController,
   BarElement,
-  CategoryScale,
   Chart,
   ChartData,
   ChartDataset,
@@ -37,7 +35,6 @@ import AnnotationPlugin, {
 Chart.register(
 
   // controllers
-  BarController,
   CandlestickController,
   LineController,
   Tooltip,
@@ -53,7 +50,6 @@ Chart.register(
   Filler,
 
   // scales
-  CategoryScale,
   LinearScale,
   TimeSeriesScale
 );

--- a/client/src/app/services/config.service.ts
+++ b/client/src/app/services/config.service.ts
@@ -16,7 +16,7 @@ import {
   ChartDataset,
   ChartOptions,
   FontSpec,
-  ScaleOptions,
+  ScaleOptions
 } from 'chart.js';
 
 // plugins

--- a/client/src/app/services/config.service.ts
+++ b/client/src/app/services/config.service.ts
@@ -26,7 +26,9 @@ import {
   ScaleValue
 } from 'chartjs-plugin-annotation';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class ChartConfigService {
 
   constructor(

--- a/client/src/app/services/user.service.ts
+++ b/client/src/app/services/user.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
 import { UserSettings } from '../pages/chart/chart.models';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class UserService {
 
   settings: UserSettings; // initialized in app.component.ts

--- a/server/Functions/Functions.csproj
+++ b/server/Functions/Functions.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Alpaca.Markets" Version="7.1.0" />
+    <PackageReference Include="Alpaca.Markets" Version="7.1.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.0" />


### PR DESCRIPTION
Goal: use smaller module parts, e.g. `NgIf` instead of entire `CommonModule`

- [x] break `CommonModule` by only referencing needed `@angular/common/X`
- [x] move `HttpClientModule` (equivalent) to where `ApiService is loaded, needed only`
- [x] fix: ref: to `chart.js` to smaller needs, if possible