### PR TITLE
fix: Metadata labels for Picker

### DIFF
--- a/server/WebApi/Endpoints.cs
+++ b/server/WebApi/Endpoints.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using WebApi.Models;
 using WebApi.Services;
 
 namespace WebApi.Controllers;

--- a/server/WebApi/Services/Service.Metadata.cs
+++ b/server/WebApi/Services/Service.Metadata.cs
@@ -394,7 +394,7 @@ public static class Metadata
                 Name = "ATR Trailing Stop (High/Low offset)",
                 Uiid = "ATR-STOP-HL",
                 LegendTemplate = "ATR-STOP([P1],[P2],HIGH/LOW)",
-                Endpoint = $"{baseUrl}/ATR-STOP-CLOSE/",
+                Endpoint = $"{baseUrl}/ATR-STOP-HL/",
                 Category = "price-trend",
                 ChartType = "overlay",
                 Order = Order.Front,

--- a/server/WebApi/Services/Service.Metadata.cs
+++ b/server/WebApi/Services/Service.Metadata.cs
@@ -827,7 +827,7 @@ public static class Metadata
                 Results = [
                     new() {
                         DisplayName = "Chandelier Exit",
-                        TooltipTemplate = "CHANDELIER([P1],[P2],LONG)",
+                        TooltipTemplate = "CHANDELIER([P1],[P2],SHORT)",
                         DataName = "chandelierExit",
                         DataType = "number",
                         LineType = "dash",


### PR DESCRIPTION
This pull request includes minor updates to improve code clarity and fix inconsistencies in the `WebApi` project. The key changes involve updating endpoint URLs and tooltip templates, as well as cleaning up unused imports.

### Code cleanup:
* Removed the unused `WebApi.Models` import from the `server/WebApi/Endpoints.cs` file to improve code clarity.

### Metadata updates:
* Updated the `Endpoint` property for the "ATR Trailing Stop (High/Low offset)" indicator to use the correct URL (`ATR-STOP-HL/` instead of `ATR-STOP-CLOSE/`) in `server/WebApi/Services/Service.Metadata.cs`.
* Corrected the `TooltipTemplate` for the "Chandelier Exit" indicator to use "SHORT" instead of "LONG" in `server/WebApi/Services/Service.Metadata.cs`.