### PR TITLE
fix: address open CodeRabbit review feedback on #454

### DIFF
--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -67,7 +67,8 @@ export class ApiService {
 
   // HELPERS
   requestHeader(): { headers?: HttpHeaders } {
-    const simpleHeaders = new HttpHeaders().set("Content-Type", "application/json");
+    // GET requests carry no body, so Accept is the appropriate header (not Content-Type).
+    const simpleHeaders = new HttpHeaders().set("Accept", "application/json");
 
     return { headers: simpleHeaders };
   }

--- a/libs/chartjs-financial/controllers/financial.controller.ts
+++ b/libs/chartjs-financial/controllers/financial.controller.ts
@@ -25,7 +25,12 @@ interface ControllerMetaLike {
     _startPixel: number;
     _endPixel: number;
     ticks: unknown[];
-    _length: number;
+    _length?: number;
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+    isHorizontal?: () => boolean;
     getPixelForTick: (index: number) => number;
     getPixelForValue: (value: number) => number;
     getLabelForValue: (value: number) => string;

--- a/libs/chartjs-financial/helpers/sample-size.ts
+++ b/libs/chartjs-financial/helpers/sample-size.ts
@@ -5,13 +5,28 @@
  */
 
 interface ScaleLike {
-  _length: number;
+  _length?: number;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  isHorizontal?: () => boolean;
   ticks: unknown[];
   getPixelForTick: (index: number) => number;
 }
 
+function getScaleLength(scale: ScaleLike): number {
+  if (typeof scale._length === "number") {
+    return scale._length;
+  }
+  const horizontal = scale.isHorizontal
+    ? scale.isHorizontal()
+    : scale.right - scale.left >= scale.bottom - scale.top;
+  return horizontal ? scale.right - scale.left : scale.bottom - scale.top;
+}
+
 export function computeMinSampleSize(scale: ScaleLike, pixels: number[]): number {
-  let min = scale._length;
+  let min = getScaleLength(scale);
   let prev: number | undefined;
 
   for (let i = 1; i < pixels.length; ++i) {

--- a/tests/vitepress/examples/indicators.md
+++ b/tests/vitepress/examples/indicators.md
@@ -24,11 +24,9 @@ This example demonstrates:
 import {
   createApiClient,
   ChartManager,
+  createDefaultSelection,
   loadStaticIndicatorData,
-  setupIndyCharts,
-  type ExtendedChartDataset,
-  type IndicatorListing,
-  type IndicatorSelection
+  setupIndyCharts
 } from "@facioquo/indy-charts";
 
 setupIndyCharts();
@@ -42,56 +40,30 @@ const manager = new ChartManager({
     showTooltips: true
   }
 });
-manager.initializeOverlay(document.getElementById("main-chart") as HTMLCanvasElement, quotes, 250);
 
-function defaultSelection(listing: IndicatorListing): IndicatorSelection {
-  return {
-    ucid: crypto.randomUUID(),
-    uiid: listing.uiid,
-    label: listing.legendTemplate,
-    chartType: listing.chartType,
-    params: listing.parameters?.map(param => ({
-      paramName: param.paramName,
-      displayName: param.displayName,
-      minimum: param.minimum,
-      maximum: param.maximum,
-      value: param.defaultValue
-    })) ?? [],
-    results: listing.results.map(result => ({
-      label: result.tooltipTemplate,
-      displayName: result.displayName,
-      dataName: result.dataName,
-      color: result.defaultColor,
-      lineType: result.lineType,
-      lineWidth: result.lineWidth ?? 2,
-      order: listing.order,
-      dataset: { type: "line", data: [] } as ExtendedChartDataset
-    }))
-  };
-}
+const mainCanvas = document.getElementById("main-chart") as HTMLCanvasElement | null;
+const rsiCanvas = document.getElementById("rsi-chart") as HTMLCanvasElement | null;
+if (!mainCanvas || !rsiCanvas) throw new Error("Required canvas elements not found");
+
+manager.initializeOverlay(mainCanvas, quotes, 250);
 
 const emaListing = listings.find(x => x.uiid === "EMA");
 const rsiListing = listings.find(x => x.uiid === "RSI");
 if (!emaListing || !rsiListing) throw new Error("Required indicators not available");
 
-const emaSelection = defaultSelection(emaListing);
-const emaLookback = emaSelection.params.find(p => p.paramName === "lookbackPeriods");
-if (emaLookback) emaLookback.value = 20;
+// Use the library helper to hydrate defaults, then override parameters as needed.
+const emaSelection = createDefaultSelection(emaListing, { lookbackPeriods: 20 });
 
 const emaRows = loadStaticIndicatorData(await client.getSelectionData(emaSelection, emaListing));
 manager.processSelectionData(emaSelection, emaListing, emaRows);
 manager.displaySelection(emaSelection, emaListing);
 
-const rsiSelection = defaultSelection(rsiListing);
+const rsiSelection = createDefaultSelection(rsiListing);
 const rsiRows = loadStaticIndicatorData(await client.getSelectionData(rsiSelection, rsiListing));
 manager.processSelectionData(rsiSelection, rsiListing, rsiRows);
 manager.displaySelection(rsiSelection, rsiListing);
 
-manager.createOscillator(
-  document.getElementById("rsi-chart") as HTMLCanvasElement,
-  rsiSelection,
-  rsiListing
-);
+manager.createOscillator(rsiCanvas, rsiSelection, rsiListing);
 ```
 
 ## Available Indicators
@@ -120,15 +92,13 @@ Indicator parameters are supplied through `IndicatorSelection.params`, then
 submitted with `client.getSelectionData(selection, listing)`:
 
 ```typescript
-// macdListing and defaultSelection are defined in the recipe above
-const macdSelection = defaultSelection(macdListing);
-
-// Override the defaults using the parameter names provided by the listing
-for (const param of macdSelection.params) {
-  if (param.paramName.toLowerCase().includes("fast")) param.value = 12;
-  if (param.paramName.toLowerCase().includes("slow")) param.value = 26;
-  if (param.paramName.toLowerCase().includes("signal")) param.value = 9;
-}
+// macdListing is resolved from listings (see recipe above)
+// createDefaultSelection accepts parameter overrides keyed by paramName
+const macdSelection = createDefaultSelection(macdListing, {
+  fastPeriods: 12,
+  slowPeriods: 26,
+  signalPeriods: 9
+});
 
 const rawMacd = await client.getSelectionData(macdSelection, macdListing);
 const macdRows = loadStaticIndicatorData(rawMacd);


### PR DESCRIPTION
Addresses the open review items from CodeRabbit's most recent re-review on #454. Each finding was verified against the current branch state; only items still applicable were modified.

## Changes

- **`libs/chartjs-financial/helpers/sample-size.ts` + `controllers/financial.controller.ts`** — no longer rely exclusively on the private `Scale._length`. Falls back to the public axis extents (`right - left` / `bottom - top`, guided by `isHorizontal()` when present) when the internal value is unavailable.
- **`client/src/app/services/api.service.ts`** — GET requests now send `Accept: application/json` instead of the inappropriate `Content-Type` header.
- **`tests/vitepress/examples/indicators.md`** — replaced the inline `defaultSelection` helper with the library's exported `createDefaultSelection(listing, overrides)`; added null guards around `document.getElementById` canvas lookups and tightened the MACD override snippet.

## Verified already addressed (no change needed)

- `libs/indy-charts` uses `structuredClone` throughout; remaining `JSON.parse(JSON.stringify)` is in a test serializer where stripping non-serializables is intentional.
- `libs/indy-charts/api/client.ts` already awaits `response.json()`, builds URLs via `new URL(..., baseUrl)` + `searchParams`, and sends no headers on GETs.
- No stray `--host` entry in any `.gitignore`.
- No global `"focus": true` in `.vscode/tasks.json`.
- `tests/playwright/seed.spec.ts` already asserts `toHaveTitle(/Stock Indicators/)`.
- `tests/playwright/vitepress.spec.ts` dark-mode toggle already uses the robust before/after `aria-checked` pattern.

## Test plan

- [x] `pnpm --filter @stock-charts/client run test` — 77 passed / 1 skipped
- [x] `pnpm --filter @facioquo/chartjs-chart-financial run test` — 10/10
- [x] `pnpm --filter @facioquo/indy-charts run test` — 126/126
- [x] `pnpm --filter @stock-charts/client run build` — succeeds
- [x] Prettier clean on changed files
- [ ] .NET format/build (not runnable in this sandbox; no backend code changed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpWywR26G2UvsDpyNPN32o)_