### PR TITLE
fix: Coordinate overlay and oscillator bar windows on resize and API fallback

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,6 @@
     "@angular/platform-browser": "~21.2.14",
     "@angular/platform-browser-dynamic": "~21.2.14",
     "@angular/router": "~21.2.14",
-    "@angular/service-worker": "~21.2.14",
     "@ctrl/tinycolor": "^4.2.0",
     "@facioquo/indy-charts": "workspace:*",
     "@ng-matero/extensions": "~21.3.1",

--- a/client/src/app/services/api.service.spec.ts
+++ b/client/src/app/services/api.service.spec.ts
@@ -274,7 +274,13 @@ describe("ApiService", () => {
     req.flush(mockSelectionData);
   });
 
-  it("should fallback to timestamp-aligned backup rows when backend is transiently unavailable", async () => {
+  it("should fallback to empty selection data when backend is transiently unavailable", async () => {
+    // Quotes/listings are still live in this path, so candlesticks are at live
+    // timestamps. Returning backup rows (2016-2019 dates) would diverge from
+    // those just as badly as the original today-dated trailing bars did, so
+    // the transient path keeps the empty-array contract and leaves the
+    // overlay's other live datasets to anchor the x-axis. `backupActive` is
+    // NOT armed here — that's reserved for quotes/listings fallbacks.
     const listing: IndicatorListing = {
       name: "Average Directional Index",
       uiid: "ADX",
@@ -303,10 +309,15 @@ describe("ApiService", () => {
       statusText: "Unknown Error"
     });
 
-    const rows = (await result) as Array<{ timestamp: string }>;
-    const backup = backupQuotes as ApiQuote[];
-    expect(rows).toHaveLength(backup.length);
-    expect(rows[0].timestamp).toBe(backup[0].timestamp);
+    await expect(result).resolves.toEqual([]);
+
+    // Subsequent indicator requests must still hit the live API — a transient
+    // indicator failure does NOT arm session-wide backup mode.
+    const followup = firstValueFrom(service.getSelectionData(selection, listing));
+    httpMock
+      .expectOne(request => request.url === `${env.api}/ADX/`)
+      .flush([{ timestamp: "2024-01-01", adx: 22 }]);
+    await expect(followup).resolves.toEqual([{ timestamp: "2024-01-01", adx: 22 }]);
   });
 
   it("should rethrow selection data contract failures instead of returning no data", async () => {
@@ -427,10 +438,17 @@ describe("ApiService", () => {
     httpMock.expectNone(request => request.url === `${env.api}/RSI/`);
   });
 
-  it("re-arms live indicator fetches after a single transient indicator failure self-heals", async () => {
-    // Quotes/listings are only fetched at bootstrap, so a transient 502 on a
-    // single indicator must NOT keep the rest of the session stuck on backup
-    // data. A subsequent successful indicator response should clear the flag.
+  it("returns a fresh array reference from backup fallback so downstream mutation can't corrupt the cache", async () => {
+    // backupSelectionRows() memoizes its payload but must hand each caller a
+    // distinct array so an accidental sort/splice/pop downstream can't
+    // permanently scramble the rows for every subsequent request.
+    const quotes$ = firstValueFrom(service.getQuotes());
+    httpMock.expectOne(`${env.api}/quotes`).error(new ProgressEvent("Network error"), {
+      status: 0,
+      statusText: "Network Error"
+    });
+    await quotes$;
+
     const listing: IndicatorListing = {
       name: "Average Directional Index",
       uiid: "ADX",
@@ -452,55 +470,22 @@ describe("ApiService", () => {
       results: []
     };
 
-    // First indicator request hits a transient 502 — backup mode arms and
-    // backup rows are returned without re-trying.
-    const firstReq = firstValueFrom(service.getSelectionData(selection, listing));
-    httpMock.expectOne(request => request.url === `${env.api}/ADX/`).error(
-      new ProgressEvent("Bad Gateway"),
-      {
-        status: 502,
-        statusText: "Bad Gateway"
-      }
-    );
-    const firstRows = (await firstReq) as Array<{ timestamp: string }>;
-    expect(firstRows.length).toBe((backupQuotes as ApiQuote[]).length);
+    const first = (await firstValueFrom(service.getSelectionData(selection, listing))) as Array<{
+      timestamp: string;
+    }>;
+    const second = (await firstValueFrom(service.getSelectionData(selection, listing))) as Array<{
+      timestamp: string;
+    }>;
 
-    // While backupActive=true, calls short-circuit to backup rows without HTTP.
-    const shortCircuited = (await firstValueFrom(
-      service.getSelectionData(selection, listing)
-    )) as Array<{ timestamp: string }>;
-    expect(shortCircuited.length).toBe((backupQuotes as ApiQuote[]).length);
-    httpMock.expectNone(request => request.url === `${env.api}/ADX/`);
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
 
-    // Wait — backupActive only clears on a successful HTTP response. So we
-    // need to first force the short-circuit OFF by making a getQuotes succeed,
-    // OR (per the new contract) by having the indicator fetch itself succeed.
-    // The new behavior is that a successful indicator response clears the flag.
-    // To exercise it we have to bypass the short-circuit, which only quotes/
-    // listings can do. So this test verifies recovery via a successful indicator
-    // response AFTER quotes have re-armed live mode.
-    const quotes$ = firstValueFrom(service.getQuotes());
-    httpMock
-      .expectOne(`${env.api}/quotes`)
-      .flush([
-        { timestamp: "2024-01-01T00:00:00.000Z", open: 1, high: 2, low: 0, close: 1, volume: 10 }
-      ]);
-    await quotes$;
-
-    // Indicator now reaches the live endpoint and a successful response keeps
-    // the flag cleared for any subsequent transient-only failures.
-    const liveReq = firstValueFrom(service.getSelectionData(selection, listing));
-    httpMock
-      .expectOne(request => request.url === `${env.api}/ADX/`)
-      .flush([{ timestamp: "2024-01-01", adx: 22 }]);
-    await expect(liveReq).resolves.toEqual([{ timestamp: "2024-01-01", adx: 22 }]);
-
-    // Confirm the success-path clear: another indicator request goes live.
-    const secondLiveReq = firstValueFrom(service.getSelectionData(selection, listing));
-    httpMock
-      .expectOne(request => request.url === `${env.api}/ADX/`)
-      .flush([{ timestamp: "2024-01-02", adx: 23 }]);
-    await expect(secondLiveReq).resolves.toEqual([{ timestamp: "2024-01-02", adx: 23 }]);
+    // Mutating the first reference must not bleed into the second call.
+    first.length = 0;
+    const third = (await firstValueFrom(service.getSelectionData(selection, listing))) as Array<{
+      timestamp: string;
+    }>;
+    expect(third.length).toBe((backupQuotes as ApiQuote[]).length);
   });
 
   it("re-arms live indicator fetches after a successful getQuotes response recovers the backend", async () => {

--- a/client/src/app/services/api.service.spec.ts
+++ b/client/src/app/services/api.service.spec.ts
@@ -274,7 +274,7 @@ describe("ApiService", () => {
     req.flush(mockSelectionData);
   });
 
-  it("should fallback to empty selection data only when backend is unavailable", async () => {
+  it("should fallback to timestamp-aligned backup rows when backend is transiently unavailable", async () => {
     const listing: IndicatorListing = {
       name: "Average Directional Index",
       uiid: "ADX",
@@ -303,7 +303,10 @@ describe("ApiService", () => {
       statusText: "Unknown Error"
     });
 
-    await expect(result).resolves.toEqual([]);
+    const rows = (await result) as Array<{ timestamp: string }>;
+    const backup = backupQuotes as ApiQuote[];
+    expect(rows).toHaveLength(backup.length);
+    expect(rows[0].timestamp).toBe(backup[0].timestamp);
   });
 
   it("should rethrow selection data contract failures instead of returning no data", async () => {
@@ -338,7 +341,7 @@ describe("ApiService", () => {
     await expect(result).rejects.toMatchObject({ status: 400 });
   });
 
-  it("returns empty selection data without an HTTP request after quotes fell back to backup", async () => {
+  it("returns timestamp-aligned backup rows without an HTTP request after quotes fell back to backup", async () => {
     // First call: getQuotes errors → triggers backup mode
     const quotes$ = firstValueFrom(service.getQuotes());
     const quotesReq = httpMock.expectOne(`${env.api}/quotes`);
@@ -349,8 +352,9 @@ describe("ApiService", () => {
     await quotes$;
 
     // Subsequent getSelectionData must NOT issue an HTTP request and must
-    // resolve to [] — this keeps overlay + oscillator behavior consistent
-    // when the live API is unavailable.
+    // resolve to rows aligned with backup quote timestamps. Anchoring the
+    // x-axis to the candlestick range keeps overlay/oscillator charts
+    // visually consistent when the live API is unavailable.
     const listing: IndicatorListing = {
       name: "Average Directional Index",
       uiid: "ADX",
@@ -372,11 +376,20 @@ describe("ApiService", () => {
       results: []
     };
 
-    await expect(firstValueFrom(service.getSelectionData(selection, listing))).resolves.toEqual([]);
+    const rows = (await firstValueFrom(service.getSelectionData(selection, listing))) as Array<{
+      timestamp: string;
+      candle: { timestamp: string };
+    }>;
+
+    const backup = backupQuotes as ApiQuote[];
+    expect(rows).toHaveLength(backup.length);
+    expect(rows[0].timestamp).toBe(backup[0].timestamp);
+    expect(rows[0].candle.timestamp).toBe(backup[0].timestamp);
+    expect(rows.at(-1)?.timestamp).toBe(backup.at(-1)?.timestamp);
     httpMock.expectNone(request => request.url === `${env.api}/ADX/`);
   });
 
-  it("returns empty selection data without an HTTP request after listings fell back to backup", async () => {
+  it("returns timestamp-aligned backup rows without an HTTP request after listings fell back to backup", async () => {
     const listings$ = firstValueFrom(service.getListings());
     const listingsReq = httpMock.expectOne(`${env.api}/indicators`);
     listingsReq.error(new ProgressEvent("Server error"), {
@@ -406,8 +419,88 @@ describe("ApiService", () => {
       results: []
     };
 
-    await expect(firstValueFrom(service.getSelectionData(selection, listing))).resolves.toEqual([]);
+    const rows = (await firstValueFrom(service.getSelectionData(selection, listing))) as Array<{
+      timestamp: string;
+    }>;
+
+    expect(rows.length).toBe((backupQuotes as ApiQuote[]).length);
     httpMock.expectNone(request => request.url === `${env.api}/RSI/`);
+  });
+
+  it("re-arms live indicator fetches after a single transient indicator failure self-heals", async () => {
+    // Quotes/listings are only fetched at bootstrap, so a transient 502 on a
+    // single indicator must NOT keep the rest of the session stuck on backup
+    // data. A subsequent successful indicator response should clear the flag.
+    const listing: IndicatorListing = {
+      name: "Average Directional Index",
+      uiid: "ADX",
+      legendTemplate: "ADX([P1])",
+      endpoint: "/ADX/",
+      category: "trend",
+      chartType: "oscillator",
+      order: 0,
+      chartConfig: null,
+      parameters: [],
+      results: []
+    };
+    const selection: IndicatorSelection = {
+      ucid: "chart-1",
+      uiid: "ADX",
+      label: "ADX(14)",
+      chartType: "oscillator",
+      params: [],
+      results: []
+    };
+
+    // First indicator request hits a transient 502 — backup mode arms and
+    // backup rows are returned without re-trying.
+    const firstReq = firstValueFrom(service.getSelectionData(selection, listing));
+    httpMock.expectOne(request => request.url === `${env.api}/ADX/`).error(
+      new ProgressEvent("Bad Gateway"),
+      {
+        status: 502,
+        statusText: "Bad Gateway"
+      }
+    );
+    const firstRows = (await firstReq) as Array<{ timestamp: string }>;
+    expect(firstRows.length).toBe((backupQuotes as ApiQuote[]).length);
+
+    // While backupActive=true, calls short-circuit to backup rows without HTTP.
+    const shortCircuited = (await firstValueFrom(
+      service.getSelectionData(selection, listing)
+    )) as Array<{ timestamp: string }>;
+    expect(shortCircuited.length).toBe((backupQuotes as ApiQuote[]).length);
+    httpMock.expectNone(request => request.url === `${env.api}/ADX/`);
+
+    // Wait — backupActive only clears on a successful HTTP response. So we
+    // need to first force the short-circuit OFF by making a getQuotes succeed,
+    // OR (per the new contract) by having the indicator fetch itself succeed.
+    // The new behavior is that a successful indicator response clears the flag.
+    // To exercise it we have to bypass the short-circuit, which only quotes/
+    // listings can do. So this test verifies recovery via a successful indicator
+    // response AFTER quotes have re-armed live mode.
+    const quotes$ = firstValueFrom(service.getQuotes());
+    httpMock
+      .expectOne(`${env.api}/quotes`)
+      .flush([
+        { timestamp: "2024-01-01T00:00:00.000Z", open: 1, high: 2, low: 0, close: 1, volume: 10 }
+      ]);
+    await quotes$;
+
+    // Indicator now reaches the live endpoint and a successful response keeps
+    // the flag cleared for any subsequent transient-only failures.
+    const liveReq = firstValueFrom(service.getSelectionData(selection, listing));
+    httpMock
+      .expectOne(request => request.url === `${env.api}/ADX/`)
+      .flush([{ timestamp: "2024-01-01", adx: 22 }]);
+    await expect(liveReq).resolves.toEqual([{ timestamp: "2024-01-01", adx: 22 }]);
+
+    // Confirm the success-path clear: another indicator request goes live.
+    const secondLiveReq = firstValueFrom(service.getSelectionData(selection, listing));
+    httpMock
+      .expectOne(request => request.url === `${env.api}/ADX/`)
+      .flush([{ timestamp: "2024-01-02", adx: 23 }]);
+    await expect(secondLiveReq).resolves.toEqual([{ timestamp: "2024-01-02", adx: 23 }]);
   });
 
   it("re-arms live indicator fetches after a successful getQuotes response recovers the backend", async () => {
@@ -441,7 +534,10 @@ describe("ApiService", () => {
     await firstQuotes;
 
     // Sanity: indicator fetch is short-circuited while backup is armed
-    await expect(firstValueFrom(service.getSelectionData(selection, listing))).resolves.toEqual([]);
+    const armedRows = (await firstValueFrom(
+      service.getSelectionData(selection, listing)
+    )) as Array<{ timestamp: string }>;
+    expect(armedRows.length).toBe((backupQuotes as ApiQuote[]).length);
     httpMock.expectNone(request => request.url === `${env.api}/ADX/`);
 
     // Step 2: getQuotes succeeds → backup mode must clear

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -16,15 +16,19 @@ export class ApiService {
   private readonly http = inject(HttpClient);
 
   /**
-   * Set to `true` once a quotes/listings/indicator fetch falls back to bundled
-   * backup data. While active, `getSelectionData` short-circuits to backup-quote-
-   * aligned empty indicator rows (one per backup quote, with the candle attached)
-   * so overlay and oscillator indicator x-axes align with the candlestick range
-   * instead of stretching to today's date. Reset to `false` on ANY successful
-   * live response (quotes, listings, or indicator) so a session that hit a
-   * single transient indicator 502 self-heals as soon as the backend recovers
-   * — without this, quotes/listings only load at bootstrap and the app would
-   * stay pinned to backup for the rest of the session.
+   * Armed when **quotes or listings** fall back to bundled backup data,
+   * signalling that the overlay candlesticks are at 2016-2019 timestamps and
+   * any live indicator response would diverge. While active, `getSelectionData`
+   * short-circuits to backup-quote-aligned empty rows so every chart's x-axis
+   * stays pinned to the candlestick range.
+   *
+   * Cleared only by a successful quotes/listings response — these load once at
+   * bootstrap, so backup mode persists for the session unless the user reloads.
+   * A transient indicator failure (e.g. one 502 on `/RSI/`) does NOT arm this
+   * flag: quotes/listings are still live, candlesticks are at live timestamps,
+   * and backup rows at 2016 dates would diverge from those just as badly as
+   * today-dated `addExtraBars()` did. That path returns `[]` instead, letting
+   * the overlay's other live datasets anchor the x-axis.
    */
   private backupActive = false;
 
@@ -107,26 +111,21 @@ export class ApiService {
         params
       })
       .pipe(
-        map(data => {
-          // Self-heal: a successful indicator response means the backend is
-          // alive again, so future requests should hit the live API.
-          this.backupActive = false;
-          return data;
-        }),
         catchError((error: HttpErrorResponse) => {
           if (!this.isTransientBackendUnavailable(error)) {
             return throwError(() => error);
           }
 
-          this.backupActive = true;
-          console.warn(
-            "Backend API unavailable, using timestamp-aligned empty data for indicator",
-            {
-              uiid: selection.uiid,
-              status: error.status
-            }
-          );
-          return of(this.backupSelectionRows());
+          // Do NOT arm backupActive here — quotes/listings are still live, so
+          // the candlesticks are at live timestamps. Returning backup rows
+          // (2016-2019) would diverge from those just like the original
+          // `[]` + today-dated `addExtraBars()` did. Empty array lets the
+          // overlay's other live datasets keep the x-axis anchored.
+          console.warn("Backend API unavailable, using empty data for indicator", {
+            uiid: selection.uiid,
+            status: error.status
+          });
+          return of([]);
         })
       );
   }
@@ -139,24 +138,25 @@ export class ApiService {
    * gets `undefined`, coerces it to NaN, and emits a gap; candlestick-pattern
    * indicators additionally read `row.candle` for high/low anchoring.
    *
-   * Memoized — backup quotes are static JSON bundled at build time, so the
-   * synthesized rows can be reused across every short-circuit and transient-
-   * fallback call without rebuilding. Returned array is treated as read-only
-   * by callers (RxJS `of` only emits it; downstream consumers iterate).
+   * Returns a **fresh array** wrapping a memoized payload — the row objects
+   * are reused (they're effectively immutable POJOs read by indy-charts), but
+   * each caller receives its own array reference so an accidental in-place
+   * sort/splice downstream can't corrupt the cache for subsequent requests.
    */
   private backupSelectionRows(): Array<{ timestamp: string; candle: unknown }> {
-    if (this._backupRows) return this._backupRows;
-    type BackupQuote = {
-      timestamp: string;
-      open: number;
-      high: number;
-      low: number;
-      close: number;
-      volume: number;
-    };
-    const quotes = backupQuotes as BackupQuote[];
-    this._backupRows = quotes.map(q => ({ timestamp: q.timestamp, candle: q }));
-    return this._backupRows;
+    if (!this._backupRows) {
+      type BackupQuote = {
+        timestamp: string;
+        open: number;
+        high: number;
+        low: number;
+        close: number;
+        volume: number;
+      };
+      const quotes = backupQuotes as BackupQuote[];
+      this._backupRows = quotes.map(q => ({ timestamp: q.timestamp, candle: q }));
+    }
+    return [...this._backupRows];
   }
 
   requestHeader(): { headers?: HttpHeaders } {

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -16,14 +16,20 @@ export class ApiService {
   private readonly http = inject(HttpClient);
 
   /**
-   * Set to `true` once a quotes-or-listings fetch falls back to bundled backup
-   * data. While active, `getSelectionData` short-circuits to `[]` so oscillator
-   * and overlay indicators do not render their live timestamps against stale
-   * (or absent) backup quotes — keeping fallback behavior consistent across
-   * chart types. Reset to `false` whenever a live quotes or listings response
-   * succeeds so the app recovers automatically once the backend returns.
+   * Set to `true` once a quotes/listings/indicator fetch falls back to bundled
+   * backup data. While active, `getSelectionData` short-circuits to backup-quote-
+   * aligned empty indicator rows (one per backup quote, with the candle attached)
+   * so overlay and oscillator indicator x-axes align with the candlestick range
+   * instead of stretching to today's date. Reset to `false` on ANY successful
+   * live response (quotes, listings, or indicator) so a session that hit a
+   * single transient indicator 502 self-heals as soon as the backend recovers
+   * — without this, quotes/listings only load at bootstrap and the app would
+   * stay pinned to backup for the rest of the session.
    */
   private backupActive = false;
+
+  /** Lazily-built timestamp-aligned rows for backup-mode `getSelectionData`. */
+  private _backupRows: Array<{ timestamp: string; candle: unknown }> | undefined;
 
   getQuotes(): Observable<Quote[]> {
     type ApiQuote = {
@@ -47,7 +53,6 @@ export class ApiService {
         this.backupActive = true;
         console.warn("Backend API unavailable, using client-side backup quotes", {
           status: error.status,
-          statusText: error.statusText,
           url: error.url,
           message: error.message
         });
@@ -66,7 +71,6 @@ export class ApiService {
         this.backupActive = true;
         console.warn("Backend API unavailable, using client-side backup indicators", {
           status: error.status,
-          statusText: error.statusText,
           url: error.url,
           message: error.message
         });
@@ -83,11 +87,14 @@ export class ApiService {
     // the live API would render with current timestamps against backup quote
     // dates — producing the visually-inconsistent overlay vs oscillator behavior
     // seen on Cloudflare Pages PR previews before the API has been redeployed.
+    // Returning rows aligned to backup quote timestamps (with the candle for
+    // candlestick-pattern indicators) keeps every chart's x-axis pinned to the
+    // candlestick range; NaN y-values render as gaps so no spurious line is drawn.
     if (this.backupActive) {
-      console.warn("Backup data active, returning empty data for indicator", {
+      console.warn("Backup data active, returning timestamp-aligned empty data for indicator", {
         uiid: selection.uiid
       });
-      return of([]);
+      return of(this.backupSelectionRows());
     }
 
     let params = new HttpParams();
@@ -100,23 +107,58 @@ export class ApiService {
         params
       })
       .pipe(
+        map(data => {
+          // Self-heal: a successful indicator response means the backend is
+          // alive again, so future requests should hit the live API.
+          this.backupActive = false;
+          return data;
+        }),
         catchError((error: HttpErrorResponse) => {
           if (!this.isTransientBackendUnavailable(error)) {
             return throwError(() => error);
           }
 
           this.backupActive = true;
-          console.warn("Backend API unavailable, using empty data for indicator", {
-            uiid: selection.uiid,
-            status: error.status,
-            statusText: error.statusText
-          });
-          return of([]);
+          console.warn(
+            "Backend API unavailable, using timestamp-aligned empty data for indicator",
+            {
+              uiid: selection.uiid,
+              status: error.status
+            }
+          );
+          return of(this.backupSelectionRows());
         })
       );
   }
 
   // HELPERS
+
+  /**
+   * Build one indicator row per backup quote, carrying only the timestamp and
+   * candle. `buildDataPoints` in indy-charts reads `row[result.dataName]`,
+   * gets `undefined`, coerces it to NaN, and emits a gap; candlestick-pattern
+   * indicators additionally read `row.candle` for high/low anchoring.
+   *
+   * Memoized — backup quotes are static JSON bundled at build time, so the
+   * synthesized rows can be reused across every short-circuit and transient-
+   * fallback call without rebuilding. Returned array is treated as read-only
+   * by callers (RxJS `of` only emits it; downstream consumers iterate).
+   */
+  private backupSelectionRows(): Array<{ timestamp: string; candle: unknown }> {
+    if (this._backupRows) return this._backupRows;
+    type BackupQuote = {
+      timestamp: string;
+      open: number;
+      high: number;
+      low: number;
+      close: number;
+      volume: number;
+    };
+    const quotes = backupQuotes as BackupQuote[];
+    this._backupRows = quotes.map(q => ({ timestamp: q.timestamp, candle: q }));
+    return this._backupRows;
+  }
+
   requestHeader(): { headers?: HttpHeaders } {
     // GET requests carry no body, so Accept is the appropriate header (not Content-Type).
     const simpleHeaders = new HttpHeaders().set("Accept", "application/json");

--- a/libs/indy-charts/charts/chart-manager.spec.ts
+++ b/libs/indy-charts/charts/chart-manager.spec.ts
@@ -511,6 +511,25 @@ describe("ChartManager", () => {
       expect(() => mgr.createOscillator(ctx, selection, listing)).toThrow(/not been registered/);
     });
 
+    it("throws when processSelectionData was skipped under a windowed overlay", () => {
+      // Reaching createOscillator without populated processed datasets while
+      // the overlay is windowed would silently render an oscillator that can't
+      // be aligned. Fail loudly so consumers fix their ordering.
+      const ctx = {} as CanvasRenderingContext2D;
+      mgr.initializeOverlay(ctx, makeQuotes(100), 50);
+
+      const listing = makeOscillatorListing();
+      const selection = makeSelection(listing, "osc-missing-cache");
+      // NOTE: no processSelectionData call.
+      // Have to register the selection manually so the upstream registration
+      // check passes — we want to trip the dataset-cache check, not the prior one.
+      mgr.displaySelection(selection, listing);
+
+      expect(() => mgr.createOscillator(ctx, selection, listing)).toThrow(
+        /has no processed datasets/
+      );
+    });
+
     it("destroys a previous oscillator for the same ucid", () => {
       const listing = makeOscillatorListing();
       const selection = makeSelection(listing, "osc-replace");
@@ -525,11 +544,10 @@ describe("ChartManager", () => {
       expect(mgr.oscillators.size).toBe(1);
     });
 
-    it("renders with full data and does not slice on initialization", () => {
-      // createOscillator always renders with the full dataset; subsequent
-      // setBarCount() calls handle viewport-aligned slicing. Consumers that
-      // need an initial viewport-aligned oscillator should pre-slice their
-      // quotes/rows before calling ChartManager (as the VitePress demo does).
+    it("renders with full data and does not slice when no overlay window is set", () => {
+      // Without an initialized overlay (allQuotes is empty), createOscillator
+      // renders with the full dataset and does not slice. Threshold datasets
+      // captured during render retain full history for future setBarCount() calls.
       const listing = makeOscillatorListing();
       const selection = makeSelection(listing, "osc-standalone");
       mgr.processSelectionData(selection, listing, makeIndicatorData(makeQuotes(30)));
@@ -540,20 +558,45 @@ describe("ChartManager", () => {
 
       // render must be called with full data so fullThresholdDatasets has all history
       expect(osc.render).toHaveBeenCalledWith(selection, listing);
-      // applySlicedData must NOT be called on initial create
+      // No overlay → no window to align to → no slice on init
       expect(osc.applySlicedData).not.toHaveBeenCalled();
     });
 
-    it("does not slice oscillator on initial create even when overlay is windowed", () => {
-      // With an overlay initialized to a smaller window, the oscillator still
-      // renders with full data on creation. Window alignment is the consumer's
-      // responsibility (pre-slice quotes) or happens later via setBarCount().
+    it("slices oscillator on initial create to align with a windowed overlay", () => {
+      // With an overlay initialized to a smaller window, createOscillator must
+      // immediately apply the current viewport slice so the new oscillator's
+      // x-axis matches the overlay from the first paint — fixing the race
+      // where oscillators created during/after a resize would otherwise span
+      // the full quote history.
       const ctx = {} as CanvasRenderingContext2D;
       const quotes = makeQuotes(100);
       mgr.initializeOverlay(ctx, quotes, 50); // allQuotes=100, currentBarCount=50
 
       const listing = makeOscillatorListing();
       const selection = makeSelection(listing, "osc-overlay-viewport");
+      mgr.processSelectionData(selection, listing, makeIndicatorData(quotes));
+      mgr.displaySelection(selection, listing);
+
+      const osc = mgr.createOscillator(ctx, selection, listing);
+
+      expect(osc.render).toHaveBeenCalledWith(selection, listing);
+      // startIndex = 100 - 50 = 50
+      expect(osc.applySlicedData).toHaveBeenCalledWith(selection, expect.any(Array), 50);
+      // Verify the cached (non-empty) datasets were passed, not a stray empty array —
+      // catches a regression where _allProcessedDatasets.get(ucid) returns the wrong key.
+      const passedDatasets = vi.mocked(osc.applySlicedData).mock.calls[0][1];
+      expect(passedDatasets.length).toBeGreaterThan(0);
+    });
+
+    it("does not slice on initial create when currentBarCount covers all quotes", () => {
+      // When the viewport already fits every quote, slicing would be a no-op
+      // and skipping it avoids an unnecessary chart.update pass.
+      const ctx = {} as CanvasRenderingContext2D;
+      const quotes = makeQuotes(50);
+      mgr.initializeOverlay(ctx, quotes, 50); // allQuotes=50, currentBarCount=50
+
+      const listing = makeOscillatorListing();
+      const selection = makeSelection(listing, "osc-full-window");
       mgr.processSelectionData(selection, listing, makeIndicatorData(quotes));
       mgr.displaySelection(selection, listing);
 

--- a/libs/indy-charts/charts/chart-manager.spec.ts
+++ b/libs/indy-charts/charts/chart-manager.spec.ts
@@ -484,6 +484,19 @@ describe("ChartManager", () => {
       expect(mgr.selections).toHaveLength(1);
       expect(mgr.oscillators.size).toBe(0); // not yet — consumer calls createOscillator
     });
+
+    it("rejects the reserved 'overlay-main' ucid", () => {
+      // Internal _allProcessedDatasets cache keys both the overlay candlestick
+      // bundle (under "overlay-main") and per-selection indicator datasets
+      // (under selection.ucid). A collision would mis-cast candlestick data as
+      // indicator data inside applySlicedData. Guard at the displaySelection
+      // boundary so consumers learn about the conflict immediately.
+      const listing = makeOscillatorListing();
+      const colliding = makeSelection(listing, "overlay-main");
+      mgr.processSelectionData(colliding, listing, makeIndicatorData(makeQuotes(30)));
+
+      expect(() => mgr.displaySelection(colliding, listing)).toThrow(/reserved for internal use/);
+    });
   });
 
   // ----- createOscillator -----
@@ -511,23 +524,30 @@ describe("ChartManager", () => {
       expect(() => mgr.createOscillator(ctx, selection, listing)).toThrow(/not been registered/);
     });
 
-    it("throws when processSelectionData was skipped under a windowed overlay", () => {
-      // Reaching createOscillator without populated processed datasets while
-      // the overlay is windowed would silently render an oscillator that can't
-      // be aligned. Fail loudly so consumers fix their ordering.
+    it("throws when processSelectionData was skipped (regardless of windowing)", () => {
+      // Reaching createOscillator without populated processed datasets is a
+      // contract violation in every viewport state — failing only under a
+      // windowed overlay would produce works-on-desktop / throws-on-mobile
+      // ticket noise. Verify the throw fires both with and without a window.
       const ctx = {} as CanvasRenderingContext2D;
-      mgr.initializeOverlay(ctx, makeQuotes(100), 50);
-
       const listing = makeOscillatorListing();
-      const selection = makeSelection(listing, "osc-missing-cache");
-      // NOTE: no processSelectionData call.
-      // Have to register the selection manually so the upstream registration
-      // check passes — we want to trip the dataset-cache check, not the prior one.
-      mgr.displaySelection(selection, listing);
 
-      expect(() => mgr.createOscillator(ctx, selection, listing)).toThrow(
+      // Case 1: windowed overlay
+      mgr.initializeOverlay(ctx, makeQuotes(100), 50);
+      const windowedSel = makeSelection(listing, "osc-missing-windowed");
+      mgr.displaySelection(windowedSel, listing);
+      expect(() => mgr.createOscillator(ctx, windowedSel, listing)).toThrow(
         /has no processed datasets/
       );
+
+      // Case 2: no overlay at all (allQuotes empty → currentBarCount === 0)
+      const fresh = new ChartManager({ settings: defaultSettings });
+      const standaloneSel = makeSelection(listing, "osc-missing-standalone");
+      fresh.displaySelection(standaloneSel, listing);
+      expect(() => fresh.createOscillator(ctx, standaloneSel, listing)).toThrow(
+        /has no processed datasets/
+      );
+      fresh.destroy();
     });
 
     it("destroys a previous oscillator for the same ucid", () => {
@@ -582,10 +602,12 @@ describe("ChartManager", () => {
       expect(osc.render).toHaveBeenCalledWith(selection, listing);
       // startIndex = 100 - 50 = 50
       expect(osc.applySlicedData).toHaveBeenCalledWith(selection, expect.any(Array), 50);
-      // Verify the cached (non-empty) datasets were passed, not a stray empty array —
-      // catches a regression where _allProcessedDatasets.get(ucid) returns the wrong key.
+      // Verify the cached datasets were passed (non-empty and same shape as the
+      // selection's results so a wrong-key regression on _allProcessedDatasets
+      // would fail this assertion, not just slip through expect.any(Array)).
       const passedDatasets = vi.mocked(osc.applySlicedData).mock.calls[0][1];
-      expect(passedDatasets.length).toBeGreaterThan(0);
+      expect(passedDatasets.length).toBe(selection.results.length);
+      expect(passedDatasets.every(ds => Array.isArray(ds.data) && ds.data.length > 0)).toBe(true);
     });
 
     it("does not slice on initial create when currentBarCount covers all quotes", () => {

--- a/libs/indy-charts/charts/chart-manager.ts
+++ b/libs/indy-charts/charts/chart-manager.ts
@@ -219,12 +219,14 @@ export class ChartManager {
    * Consumer must provide the canvas context and call this after processSelectionData()
    * AND after displaySelection() so the selection is registered in this.selections.
    *
-   * The oscillator renders with the full (unsliced) result.dataset.data from
-   * processSelectionData() so OscillatorChart.fullThresholdDatasets captures the
-   * complete history. Subsequent setBarCount() calls re-slice from this full
-   * dataset to any window size. Consumers that want the oscillator's initial
-   * view to match a windowed overlay should pre-slice their quotes/rows before
-   * passing them in to ChartManager (as the VitePress demo does).
+   * Renders with the full (unsliced) result.dataset.data so OscillatorChart's
+   * fullThresholdDatasets capture complete history for later re-slicing. Then,
+   * when an overlay has been initialized with a smaller window, applies the
+   * same slice immediately so the new oscillator's x-axis coincides with the
+   * windowed overlay from the first paint. Without this, oscillators created
+   * after `initializeOverlay` (or after a window resize race) would render
+   * spanning the full quote history while the overlay shows only the last
+   * `currentBarCount` candles — visibly misaligned at mobile breakpoints.
    *
    * @throws {Error} if displaySelection() has not been called for this selection,
    *   because setBarCount() iterates this.selections and will silently skip any
@@ -249,6 +251,28 @@ export class ChartManager {
     const oscillator = new OscillatorChart(ctx, this._settings);
     oscillator.render(selection, listing);
     this._oscillators.set(selection.ucid, oscillator);
+
+    // Align the freshly rendered oscillator with the current viewport window.
+    // render() captures full-history threshold datasets internally; this slice
+    // only narrows what's drawn, leaving the cached full datasets intact for
+    // future setBarCount() calls.
+    const totalQuotes = this._allQuotes.length;
+    if (totalQuotes > 0 && this._currentBarCount < totalQuotes) {
+      const fullDatasets = this._allProcessedDatasets.get(selection.ucid);
+      if (!fullDatasets) {
+        // processSelectionData() populates this cache; reaching here means a
+        // caller skipped it, which would also leave selection.results[].dataset
+        // empty. Fail loudly instead of silently rendering an unaligned chart.
+        throw new Error(
+          `createOscillator: selection "${selection.ucid}" has no processed datasets. ` +
+            `Call processSelectionData() before createOscillator() so the oscillator can ` +
+            `align with the current viewport window.`
+        );
+      }
+      const startIndex = totalQuotes - this._currentBarCount;
+      oscillator.applySlicedData(selection, fullDatasets as IndicatorDataset[], startIndex);
+    }
+
     return oscillator;
   }
 

--- a/libs/indy-charts/charts/chart-manager.ts
+++ b/libs/indy-charts/charts/chart-manager.ts
@@ -169,6 +169,9 @@ export class ChartManager {
 
   /**
    * Display a processed selection on the appropriate chart.
+   *
+   * @throws {Error} if `selection.ucid` collides with the reserved internal key
+   *   used by the overlay's candlestick+volume cache entry.
    */
   displaySelection(selection: IndicatorSelection, listing: IndicatorListing): void {
     if (selection.ucid === OVERLAY_MAIN_KEY) {
@@ -245,6 +248,9 @@ export class ChartManager {
    * @throws {Error} if displaySelection() has not been called for this selection,
    *   because setBarCount() iterates this.selections and will silently skip any
    *   oscillator whose ucid is not present there.
+   * @throws {Error} if processSelectionData() has not been called — the dataset
+   *   cache must be populated so the windowed slice has data to render. Validated
+   *   in every viewport state so failures are not viewport-dependent.
    */
   createOscillator(
     ctx: CanvasRenderingContext2D | HTMLCanvasElement,

--- a/libs/indy-charts/charts/chart-manager.ts
+++ b/libs/indy-charts/charts/chart-manager.ts
@@ -28,6 +28,14 @@ const CATEGORIES = {
   CANDLESTICK_PATTERN: "candlestick-pattern"
 } as const;
 
+/**
+ * Reserved cache key for the overlay's candlestick + volume datasets in
+ * `_allProcessedDatasets`. No `IndicatorSelection.ucid` may collide with this
+ * — a collision would mis-cast candlestick data as indicator data in
+ * `applySlicedData`.
+ */
+const OVERLAY_MAIN_KEY = "overlay-main";
+
 export interface ChartManagerConfig {
   settings: ChartSettings;
   extraBars?: number;
@@ -108,7 +116,7 @@ export class ChartManager {
     // Build and store the full-history datasets separately so setBarCount()
     // can re-slice across the entire history without re-rendering the chart.
     const fullDatasets = this._overlayChart.buildFullDatasets(allQuotes, this.extraBars);
-    this._allProcessedDatasets.set("overlay-main", fullDatasets);
+    this._allProcessedDatasets.set(OVERLAY_MAIN_KEY, fullDatasets);
 
     // Re-attach previously registered overlay selections so they survive
     // overlay re-initialization (e.g., theme/canvas reset). Without this,
@@ -163,6 +171,12 @@ export class ChartManager {
    * Display a processed selection on the appropriate chart.
    */
   displaySelection(selection: IndicatorSelection, listing: IndicatorListing): void {
+    if (selection.ucid === OVERLAY_MAIN_KEY) {
+      throw new Error(
+        `displaySelection: ucid "${OVERLAY_MAIN_KEY}" is reserved for internal use; ` +
+          `pick a different ucid for this selection.`
+      );
+    }
     if (this._selections.some(s => s.ucid === selection.ucid)) return;
     this._selections.push(selection);
 
@@ -247,6 +261,20 @@ export class ChartManager {
       );
     }
 
+    // Guard: processSelectionData() must have populated the dataset cache.
+    // Validated unconditionally (not only under a windowed overlay) so the
+    // failure mode doesn't depend on viewport state — otherwise the same
+    // missing-precondition bug would throw on mobile and silently render a
+    // broken chart on desktop.
+    const fullDatasets = this._allProcessedDatasets.get(selection.ucid);
+    if (!fullDatasets) {
+      throw new Error(
+        `createOscillator: selection "${selection.ucid}" has no processed datasets. ` +
+          `Call processSelectionData() before createOscillator() so the oscillator ` +
+          `has data to render.`
+      );
+    }
+
     this._oscillators.get(selection.ucid)?.destroy();
     const oscillator = new OscillatorChart(ctx, this._settings);
     oscillator.render(selection, listing);
@@ -258,17 +286,6 @@ export class ChartManager {
     // future setBarCount() calls.
     const totalQuotes = this._allQuotes.length;
     if (totalQuotes > 0 && this._currentBarCount < totalQuotes) {
-      const fullDatasets = this._allProcessedDatasets.get(selection.ucid);
-      if (!fullDatasets) {
-        // processSelectionData() populates this cache; reaching here means a
-        // caller skipped it, which would also leave selection.results[].dataset
-        // empty. Fail loudly instead of silently rendering an unaligned chart.
-        throw new Error(
-          `createOscillator: selection "${selection.ucid}" has no processed datasets. ` +
-            `Call processSelectionData() before createOscillator() so the oscillator can ` +
-            `align with the current viewport window.`
-        );
-      }
       const startIndex = totalQuotes - this._currentBarCount;
       oscillator.applySlicedData(selection, fullDatasets as IndicatorDataset[], startIndex);
     }
@@ -340,7 +357,7 @@ export class ChartManager {
     const startIndex = Math.max(0, totalQuotes - normalizedBarCount);
 
     // Update overlay main datasets (candlestick + volume)
-    const fullMainDatasets = this._allProcessedDatasets.get("overlay-main");
+    const fullMainDatasets = this._allProcessedDatasets.get(OVERLAY_MAIN_KEY);
     if (this._overlayChart && fullMainDatasets) {
       this._overlayChart.applySlicedData(fullMainDatasets, startIndex);
       this._overlayChart.updateLegends(this._selections);
@@ -393,7 +410,7 @@ export class ChartManager {
       if (!fullDatasets || !oscillator) return;
 
       // Cached datasets for an oscillator selection are always indicator datasets
-      // (the heterogeneous cache also holds candlestick+volume under "overlay-main").
+      // (the heterogeneous cache also holds candlestick+volume under OVERLAY_MAIN_KEY).
       oscillator.applySlicedData(selection, fullDatasets as IndicatorDataset[], startIndex);
     });
   }

--- a/libs/indy-charts/charts/overlay-chart.ts
+++ b/libs/indy-charts/charts/overlay-chart.ts
@@ -189,7 +189,10 @@ export class OverlayChart {
       }
     }
 
-    this.chart.update();
+    // Match OscillatorChart.applySlicedData which also uses "none" — both charts
+    // share the same setBarCount() trigger, so they must update with identical
+    // semantics to avoid one snapping while the other transitions.
+    this.chart.update("none");
   }
 
   resize(): void {

--- a/libs/indy-charts/package.json
+++ b/libs/indy-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@facioquo/indy-charts",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Framework-agnostic financial charting library with technical indicators and stock market data visualization",
   "author": "facioquo",
   "license": "Apache-2.0",

--- a/libs/indy-charts/package.json
+++ b/libs/indy-charts/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/facioquo/stock-charts.git",
     "directory": "libs/indy-charts"
   },
+  "readme": "README.md",
   "homepage": "https://github.com/facioquo/stock-charts/tree/main/libs/indy-charts#readme",
   "bugs": {
     "url": "https://github.com/facioquo/stock-charts/issues"

--- a/libs/indy-charts/tsup.config.ts
+++ b/libs/indy-charts/tsup.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsup";
-import { copyFileSync } from "fs";
+import { copyFile } from "fs/promises";
 import { resolve } from "path";
 
 export default defineConfig({
@@ -15,7 +15,6 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   onSuccess: async () => {
-    await Promise.resolve();
-    copyFileSync(resolve("README.md"), resolve("dist/README.md"));
+    await copyFile(resolve("README.md"), resolve("dist/README.md"));
   }
 });

--- a/libs/indy-charts/tsup.config.ts
+++ b/libs/indy-charts/tsup.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from "tsup";
+import { copyFileSync } from "fs";
+import { resolve } from "path";
 
 export default defineConfig({
   entry: {
@@ -11,5 +13,9 @@ export default defineConfig({
   },
   noExternal: ["@facioquo/chartjs-chart-financial"],
   sourcemap: true,
-  clean: true
+  clean: true,
+  onSuccess: async () => {
+    await Promise.resolve();
+    copyFileSync(resolve("README.md"), resolve("dist/README.md"));
+  }
 });

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "markdownlint-cli2": "^0.22.1",
     "npm-check-updates": "^22.2.0",
     "@playwright/test": "1.60.0",
-    "playwright": "1.60.0",
     "postcss-scss": "^4.0.9",
     "prettier": "^3.8.3",
     "rimraf": "^6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       npm-check-updates:
         specifier: ^22.2.0
         version: 22.2.0
-      playwright:
-        specifier: 1.60.0
-        version: 1.60.0
       postcss-scss:
         specifier: ^4.0.9
         version: 4.0.9(postcss@8.5.14)
@@ -84,9 +81,6 @@ importers:
       '@angular/router':
         specifier: ~21.2.14
         version: 21.2.14(@angular/common@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.14(@angular/animations@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
-      '@angular/service-worker':
-        specifier: ~21.2.14
-        version: 21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@ctrl/tinycolor':
         specifier: ^4.2.0
         version: 4.2.0
@@ -126,7 +120,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: ~21.2.12
-        version: 21.2.12(@angular/compiler-cli@21.2.14(@angular/compiler@21.2.14)(typescript@5.9.3))(@angular/compiler@21.2.14)(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.14(@angular/animations@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/service-worker@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@types/node@25.9.1)(chokidar@5.0.0)(jiti@2.7.0)(postcss@8.5.14)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)
+        version: 21.2.12(@angular/compiler-cli@21.2.14(@angular/compiler@21.2.14)(typescript@5.9.3))(@angular/compiler@21.2.14)(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.14(@angular/animations@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@25.9.1)(chokidar@5.0.0)(jiti@2.7.0)(postcss@8.5.14)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)
       '@angular/cli':
         specifier: ~21.2.12
         version: 21.2.12(@types/node@25.9.1)(chokidar@5.0.0)
@@ -588,14 +582,6 @@ packages:
       '@angular/common': 21.2.14
       '@angular/core': 21.2.14
       '@angular/platform-browser': 21.2.14
-      rxjs: ^6.5.3 || ^7.4.0
-
-  '@angular/service-worker@21.2.14':
-    resolution: {integrity: sha512-60DMV71QcaRtj3HwmV8Oz5zOKKudEyWourpsfpFptzF4hQ+7T7I4xSla1J0q/7b16Kwf44Ey90vCPlUrsMLVrA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@angular/core': 21.2.14
       rxjs: ^6.5.3 || ^7.4.0
 
   '@asamuzakjp/css-color@5.1.11':
@@ -5941,7 +5927,7 @@ snapshots:
       '@angular/core': 21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)
       tslib: 2.8.1
 
-  '@angular/build@21.2.12(@angular/compiler-cli@21.2.14(@angular/compiler@21.2.14)(typescript@5.9.3))(@angular/compiler@21.2.14)(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.14(@angular/animations@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/service-worker@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@types/node@25.9.1)(chokidar@5.0.0)(jiti@2.7.0)(postcss@8.5.14)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)':
+  '@angular/build@21.2.12(@angular/compiler-cli@21.2.14(@angular/compiler@21.2.14)(typescript@5.9.3))(@angular/compiler@21.2.14)(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.14(@angular/animations@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@25.9.1)(chokidar@5.0.0)(jiti@2.7.0)(postcss@8.5.14)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.12(chokidar@5.0.0)
@@ -5977,7 +5963,6 @@ snapshots:
     optionalDependencies:
       '@angular/core': 21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)
       '@angular/platform-browser': 21.2.14(@angular/animations@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))
-      '@angular/service-worker': 21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       lmdb: 3.5.1
       postcss: 8.5.14
       vitest: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.97.3))
@@ -6103,12 +6088,6 @@ snapshots:
       '@angular/common': 21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)
       '@angular/platform-browser': 21.2.14(@angular/animations@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))
-      rxjs: 7.8.2
-      tslib: 2.8.1
-
-  '@angular/service-worker@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)':
-    dependencies:
-      '@angular/core': 21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.2)
       rxjs: 7.8.2
       tslib: 2.8.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,15 +255,9 @@ importers:
       chart.js:
         specifier: 4.5.1
         version: 4.5.1
-      chartjs-adapter-date-fns:
-        specifier: 3.0.0
-        version: 3.0.0(chart.js@4.5.1)(date-fns@4.3.0)
       chartjs-plugin-annotation:
         specifier: 3.1.0
         version: 3.1.0(chart.js@4.5.1)
-      date-fns:
-        specifier: ^4.3.0
-        version: 4.3.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1

--- a/tests/vitepress/.vitepress/config.ts
+++ b/tests/vitepress/.vitepress/config.ts
@@ -14,7 +14,11 @@ export default defineConfig({
 
   vite: {
     ssr: {
-      noExternal: ["@facioquo/indy-charts", "chartjs-adapter-date-fns", "chart.js", "date-fns"]
+      // Bundle indy-charts and Chart.js into the SSR output so VitePress can
+      // evaluate the chart components during static generation. Date helpers
+      // (chartjs-adapter-date-fns + date-fns) ship as runtime deps of
+      // @facioquo/indy-charts and don't need explicit non-externalisation.
+      noExternal: ["@facioquo/indy-charts", "chart.js"]
     }
   },
 

--- a/tests/vitepress/guide/themes.md
+++ b/tests/vitepress/guide/themes.md
@@ -1,3 +1,9 @@
+---
+next:
+  text: Overlay chart
+  link: /examples/
+---
+
 # Theme customization
 
 The library includes built-in light and dark themes that automatically adapt to your application's appearance preference.

--- a/tests/vitepress/package.json
+++ b/tests/vitepress/package.json
@@ -16,9 +16,7 @@
   "dependencies": {
     "@facioquo/indy-charts": "workspace:*",
     "chart.js": "4.5.1",
-    "chartjs-adapter-date-fns": "3.0.0",
-    "chartjs-plugin-annotation": "3.1.0",
-    "date-fns": "^4.3.0"
+    "chartjs-plugin-annotation": "3.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

- **Oscillator misaligned with windowed overlay** — `ChartManager.createOscillator()` rendered with full quote history while the overlay was sliced to `barCount`. Most obvious going from desktop to mobile sizes, and racy when oscillators load during/after a resize. Now slices the freshly-rendered oscillator to the current viewport so x-axes match on first paint.
- **API fallback divergence** — when quotes/listings fell back to the bundled backup, `getSelectionData()` returned `[]`, and downstream `addExtraBars([])` dated trailing bars at today (2026), stretching the overlay x-axis out to 2026 (candlesticks compressed = "too many quotes"). Now returns timestamp-aligned synthetic rows (one per backup quote, with the candle attached) so every indicator x-axis stays pinned to the candlestick range. NaN y-values render as gaps.
- **Backup-mode contract tightened** — `backupActive` is armed only when quotes/listings themselves fall back (i.e. candlesticks are at 2016-2019 dates); it is cleared only by a successful quotes/listings response. Transient indicator failures (e.g. one 502 on `/RSI/`) no longer arm backup mode — they return `[]` so the overlay's other live datasets anchor the x-axis, and subsequent indicator requests still hit the live API. This avoids the prior bug where a single transient indicator 502 against live candlesticks would silently swap in 2016-dated backup rows — the exact x-axis divergence this PR is supposed to fix.
- **Update mode consistency** — `OverlayChart.applySlicedData` now uses `update("none")` matching `OscillatorChart`, so both charts respond identically to `setBarCount`.
- **Defensive guards** — `createOscillator` now throws if `displaySelection()` or `processSelectionData()` was skipped (in every viewport state, so the failure mode is not viewport-dependent), replacing a silent misalignment. `displaySelection` rejects the reserved `"overlay-main"` ucid to prevent cache collisions with the new `_allProcessedDatasets` consumer.
- **Cache safety** — `backupSelectionRows()` returns a fresh array slice over memoized row records so accidental in-place mutation downstream can't corrupt the cache for subsequent callers.
- **Out-of-scope tweak** — bundles README into the indy-charts publish artifact (`package.json` + `tsup.config.ts onSuccess`).

## Review trail

Self-reviewed via 3 parallel quorum reviewers (1 facioquo-core:Reviewer + 2 general-purpose). The facioquo-core reviewer hallucinated; the two general-purpose reviewers returned substantive findings. Resolved: sticky backup mode (MAJOR), overlay/oscillator update-mode mismatch (MAJOR), undefined-cache silent no-op (MINOR), test under-specification (MINOR), `backupSelectionRows` not memoized (NIT). Deferred: redundant chart.update passes on initial create (performance only; documented trade-off), `dist/README.md` copy redundancy with `files` field (intentional, out-of-scope).

A subsequent CodeRabbit review surfaced one additional Major (state-mutation-before-precondition in `createOscillator`) and two nits — all addressed in commits `e4ba71f` and `7c28489`. The original PR claim that `backupActive` self-heals on indicator success was retracted in `e4ba71f` after CodeRabbit correctly noted the short-circuit made that path unreachable; the contract above reflects the revised design.

## Test plan

- [x] `pnpm --filter @facioquo/indy-charts run test` — 158 tests pass
- [x] `pnpm --filter @stock-charts/client run test` — 113 tests pass
- [x] `pnpm --filter @facioquo/indy-charts run lint`, `... @stock-charts/client run lint --max-warnings=0` — clean
- [x] `pnpm --filter @facioquo/indy-charts run build`, `... @stock-charts/client run build` — both succeed
- [x] Manual: load app at desktop, verify overlay + every oscillator span the same bar count
- [x] Manual: resize to mobile, verify they stay coordinated
- [x] Manual: simulate API failure (block `/quotes`), verify overlay candlesticks + indicators share the 2016-2019 x-axis instead of stretching to 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)