### PR TITLE
feat: Indy-charts type unification + DX improvements

### DIFF
--- a/client/src/app/data/backup-quotes.ts
+++ b/client/src/app/data/backup-quotes.ts
@@ -50,7 +50,7 @@ function generateBackupQuotes(seed: number = 12345): Quote[] {
     currentPrice = quote.close;
   }
 
-  return quotes.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  return quotes.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 }
 
 /**

--- a/client/src/app/services/chart.service.spec.ts
+++ b/client/src/app/services/chart.service.spec.ts
@@ -226,7 +226,7 @@ describe("ChartService Smoke Tests", () => {
       getListings: vi.fn(() => of([generateSampleIndicatorListing()])),
       getSelectionData: vi.fn((_selection: IndicatorSelection) => {
         const sampleData: IndicatorDataRow[] = generateSampleQuotes(100).map(q => ({
-          timestamp: q.timestamp.toISOString(),
+          timestamp: new Date(q.timestamp).toISOString(),
           candle: q,
           sma: q.close * 0.99
         }));

--- a/libs/chartjs-financial/datasets.ts
+++ b/libs/chartjs-financial/datasets.ts
@@ -4,7 +4,7 @@ import { type FinancialDataPoint, type FinancialPalette } from "./types/financia
 import { getVolumeColor } from "./theme/colors";
 
 interface QuoteLike {
-  timestamp: Date;
+  timestamp: Date | string;
   open: number;
   high: number;
   low: number;

--- a/libs/chartjs-financial/package.json
+++ b/libs/chartjs-financial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@facioquo/chartjs-chart-financial",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Financial charting extension for Chart.js (candlestick, OHLC, volume charts)",
   "author": "facioquo",
   "license": "Apache-2.0",

--- a/libs/indy-charts/README.md
+++ b/libs/indy-charts/README.md
@@ -39,7 +39,19 @@ if (!(canvas instanceof HTMLCanvasElement)) {
 
 const chart = new OverlayChart(canvas, { isDarkTheme: false, showTooltips: true });
 chart.render(quotes.slice(-250));
+
+// In your component's unmount / cleanup hook:
+chart.destroy(); // NOT chart.chart?.destroy() — see "Teardown contract" below
 ```
+
+### Teardown contract
+
+`OverlayChart`, `OscillatorChart`, and `ChartManager` all expose a `destroy()`
+method that tears down both the wrapping library state (theme listeners,
+threshold caches, legend annotations) **and** the underlying Chart.js
+instance. Always call the wrapper's `destroy()` — never reach into
+`chart.chart?.destroy()`, which only tears down Chart.js and leaks the
+library-level state.
 
 For indicators, the responsive viewport, and oscillator subcharts, use `ChartManager`:
 

--- a/libs/indy-charts/README.md
+++ b/libs/indy-charts/README.md
@@ -152,7 +152,7 @@ Use the global component from Markdown / templates. Each instance is self-contai
 | `ChartManager` | Lifecycle orchestrator for overlay + oscillator charts and viewport changes |
 | `OverlayChart`, `OscillatorChart` | Lower-level chart classes if you don't need `ChartManager` |
 | `createApiClient(config)` | Typed `fetch` client for `GET /quotes`, `GET /indicators`, indicator data |
-| `loadStaticQuotes`, `loadStaticIndicatorData` | Normalize bring-your-own quote and indicator arrays |
+| `loadStaticQuotes`, `loadStaticIndicatorData` | Accept bring-your-own `Quote[]` / `IndicatorDataRow[]` (timestamps as string or Date) |
 | `createDefaultSelection`, `applySelectionTokens`, `calculateOptimalBars` | Selection / viewport helpers |
 | `getThemeColors`, `baseOverlayConfig`, `baseOscillatorConfig` | Theme + config building blocks |
 | `setupIndyChartsForVue` (`/vue` subpath) | Vue 3 adapter that registers `<StockIndicatorChart>` globally |

--- a/libs/indy-charts/README.md
+++ b/libs/indy-charts/README.md
@@ -47,11 +47,11 @@ chart.destroy(); // NOT chart.chart?.destroy() — see "Teardown contract" below
 ### Teardown contract
 
 `OverlayChart`, `OscillatorChart`, and `ChartManager` all expose a `destroy()`
-method that tears down both the wrapping library state (theme listeners,
-threshold caches, legend annotations) **and** the underlying Chart.js
-instance. Always call the wrapper's `destroy()` — never reach into
-`chart.chart?.destroy()`, which only tears down Chart.js and leaks the
-library-level state.
+method that releases the wrapper's cached state (legend selections, threshold
+datasets, full quote/dataset history on `ChartManager`) **and** tears down
+the underlying Chart.js instance. Always call the wrapper's `destroy()` —
+never reach into `chart.chart?.destroy()`, which only tears down Chart.js
+and leaks the wrapper's cached state.
 
 For indicators, the responsive viewport, and oscillator subcharts, use `ChartManager`:
 

--- a/libs/indy-charts/api/client.spec.ts
+++ b/libs/indy-charts/api/client.spec.ts
@@ -154,8 +154,9 @@ describe("createApiClient", () => {
       const quotes = await client.getQuotes();
 
       expect(quotes).toHaveLength(2);
-      expect(quotes[0].timestamp).toBeInstanceOf(Date);
-      expect(quotes[0].timestamp.toISOString()).toBe("2024-01-01T00:00:00.000Z");
+      const firstTimestamp = quotes[0].timestamp;
+      expect(firstTimestamp).toBeInstanceOf(Date);
+      expect((firstTimestamp as Date).toISOString()).toBe("2024-01-01T00:00:00.000Z");
       expect(quotes[1].close).toBe(100);
     });
 

--- a/libs/indy-charts/api/client.ts
+++ b/libs/indy-charts/api/client.ts
@@ -4,6 +4,7 @@ import {
   type IndicatorSelection,
   type Quote
 } from "../config/types";
+import { type RawIndicatorRow } from "./static";
 
 /**
  * Configuration for {@link createApiClient}.
@@ -73,7 +74,10 @@ export interface ApiClient {
    * @returns Resolved array of raw data rows for the indicator series.
    * @throws  Re-throws any network or HTTP error (after calling `onError`).
    */
-  getSelectionData(selection: IndicatorSelection, listing: IndicatorListing): Promise<unknown[]>;
+  getSelectionData(
+    selection: IndicatorSelection,
+    listing: IndicatorListing
+  ): Promise<RawIndicatorRow[]>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -197,7 +201,7 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
     async getSelectionData(
       selection: IndicatorSelection,
       listing: IndicatorListing
-    ): Promise<unknown[]> {
+    ): Promise<RawIndicatorRow[]> {
       const endpointUrl = new URL(listing.endpoint, baseUrl);
       selection.params.forEach((p: IndicatorParam) => {
         if (p.value != null) {
@@ -212,7 +216,7 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
-        const data = (await response.json()) as unknown[];
+        const data = (await response.json()) as RawIndicatorRow[];
         return data;
       } catch (error) {
         onError?.("Error fetching selection data", error);

--- a/libs/indy-charts/api/client.ts
+++ b/libs/indy-charts/api/client.ts
@@ -1,10 +1,10 @@
 import {
+  type IndicatorDataRow,
   type IndicatorListing,
   type IndicatorParam,
   type IndicatorSelection,
   type Quote
 } from "../config/types";
-import { type RawIndicatorRow } from "./static";
 
 /**
  * Configuration for {@link createApiClient}.
@@ -77,7 +77,7 @@ export interface ApiClient {
   getSelectionData(
     selection: IndicatorSelection,
     listing: IndicatorListing
-  ): Promise<RawIndicatorRow[]>;
+  ): Promise<IndicatorDataRow[]>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -201,7 +201,7 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
     async getSelectionData(
       selection: IndicatorSelection,
       listing: IndicatorListing
-    ): Promise<RawIndicatorRow[]> {
+    ): Promise<IndicatorDataRow[]> {
       const endpointUrl = new URL(listing.endpoint, baseUrl);
       selection.params.forEach((p: IndicatorParam) => {
         if (p.value != null) {
@@ -220,7 +220,7 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
         if (!Array.isArray(body)) {
           throw new Error("Invalid selection data response: expected an array");
         }
-        return body as RawIndicatorRow[];
+        return body as IndicatorDataRow[];
       } catch (error) {
         onError?.("Error fetching selection data", error);
         throw error;

--- a/libs/indy-charts/api/client.ts
+++ b/libs/indy-charts/api/client.ts
@@ -216,8 +216,11 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
-        const data = (await response.json()) as RawIndicatorRow[];
-        return data;
+        const body = (await response.json()) as unknown;
+        if (!Array.isArray(body)) {
+          throw new Error("Invalid selection data response: expected an array");
+        }
+        return body as RawIndicatorRow[];
       } catch (error) {
         onError?.("Error fetching selection data", error);
         throw error;

--- a/libs/indy-charts/api/index.ts
+++ b/libs/indy-charts/api/index.ts
@@ -1,4 +1,3 @@
 export { createApiClient } from "./client";
 export type { ApiClient, ApiClientConfig } from "./client";
 export { loadStaticQuotes, loadStaticIndicatorData } from "./static";
-export type { RawIndicatorRow, RawQuote } from "./static";

--- a/libs/indy-charts/api/index.ts
+++ b/libs/indy-charts/api/index.ts
@@ -1,3 +1,4 @@
 export { createApiClient } from "./client";
 export type { ApiClient, ApiClientConfig } from "./client";
 export { loadStaticQuotes, loadStaticIndicatorData } from "./static";
+export type { RawQuote } from "./static";

--- a/libs/indy-charts/api/index.ts
+++ b/libs/indy-charts/api/index.ts
@@ -1,4 +1,4 @@
 export { createApiClient } from "./client";
 export type { ApiClient, ApiClientConfig } from "./client";
 export { loadStaticQuotes, loadStaticIndicatorData } from "./static";
-export type { RawQuote } from "./static";
+export type { RawIndicatorRow, RawQuote } from "./static";

--- a/libs/indy-charts/api/static.spec.ts
+++ b/libs/indy-charts/api/static.spec.ts
@@ -1,19 +1,13 @@
 import { describe, it, expect } from "vitest";
-import {
-  loadStaticQuotes,
-  loadStaticIndicatorData,
-  type RawIndicatorRow,
-  type RawQuote
-} from "./static";
+
+import { type IndicatorDataRow, type Quote } from "../config/types";
+import { loadStaticQuotes, loadStaticIndicatorData } from "./static";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createQuote(
-  dateStr: string,
-  close = 100
-): { timestamp: string; open: number; high: number; low: number; close: number; volume: number } {
+function createQuote(dateStr: string, close = 100): Quote {
   return {
     timestamp: dateStr,
     open: close - 1,
@@ -22,6 +16,13 @@ function createQuote(
     close,
     volume: 500
   };
+}
+
+function assertDate(value: Date | string): Date {
+  if (!(value instanceof Date)) {
+    throw new Error(`Expected normalized Date, got string "${value}"`);
+  }
+  return value;
 }
 
 // ---------------------------------------------------------------------------
@@ -34,7 +35,7 @@ describe("loadStaticQuotes", () => {
     const [q] = loadStaticQuotes(quotes);
 
     expect(q.timestamp).toBeInstanceOf(Date);
-    expect(q.timestamp.toISOString()).toBe("2024-01-15T00:00:00.000Z");
+    expect(assertDate(q.timestamp).toISOString()).toBe("2024-01-15T00:00:00.000Z");
   });
 
   it("preserves all OHLCV fields", () => {
@@ -69,16 +70,16 @@ describe("loadStaticQuotes", () => {
     expect(result[2].close).toBe(70);
   });
 
-  it("accepts an explicit RawQuote[] fixture", () => {
-    const fixture: RawQuote[] = [
+  it("accepts a Quote[] fixture with mixed string/Date timestamps", () => {
+    const fixture: Quote[] = [
       { timestamp: "2024-02-01T00:00:00Z", open: 1, high: 2, low: 0, close: 1.5, volume: 10 },
       { timestamp: new Date("2024-02-02T00:00:00Z"), open: 2, high: 3, low: 1, close: 2.5, volume: 20 }
     ];
     const result = loadStaticQuotes(fixture);
 
     expect(result).toHaveLength(2);
-    expect(result[0].timestamp.toISOString()).toBe("2024-02-01T00:00:00.000Z");
-    expect(result[1].timestamp.toISOString()).toBe("2024-02-02T00:00:00.000Z");
+    expect(assertDate(result[0].timestamp).toISOString()).toBe("2024-02-01T00:00:00.000Z");
+    expect(assertDate(result[1].timestamp).toISOString()).toBe("2024-02-02T00:00:00.000Z");
   });
 });
 
@@ -105,8 +106,8 @@ describe("loadStaticIndicatorData", () => {
     expect(result[0]).toStrictEqual({ timestamp: "2024-01-01", sma: null, ema: 42 });
   });
 
-  it("accepts an explicit RawIndicatorRow[] fixture", () => {
-    const fixture: RawIndicatorRow[] = [
+  it("accepts an explicit IndicatorDataRow[] fixture", () => {
+    const fixture: IndicatorDataRow[] = [
       { timestamp: "2024-03-01", sma: 100.0 },
       { timestamp: "2024-03-02", sma: 100.5, ema: 99.7 }
     ];
@@ -117,7 +118,7 @@ describe("loadStaticIndicatorData", () => {
   });
 
   it("preserves the deprecated `date` alias for v2 fixtures", () => {
-    const fixture: RawIndicatorRow[] = [
+    const fixture: IndicatorDataRow[] = [
       { date: "2024-03-01", sma: 100.0 },
       { date: "2024-03-02", sma: 100.5, ema: 99.7 }
     ];

--- a/libs/indy-charts/api/static.spec.ts
+++ b/libs/indy-charts/api/static.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { loadStaticQuotes, loadStaticIndicatorData, type RawQuote } from "./static";
+import {
+  loadStaticQuotes,
+  loadStaticIndicatorData,
+  type RawIndicatorRow,
+  type RawQuote
+} from "./static";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -98,5 +103,16 @@ describe("loadStaticIndicatorData", () => {
     const result = loadStaticIndicatorData(raw);
 
     expect(result[0]).toStrictEqual({ timestamp: "2024-01-01", sma: null, ema: 42 });
+  });
+
+  it("accepts an explicit RawIndicatorRow[] fixture", () => {
+    const fixture: RawIndicatorRow[] = [
+      { timestamp: "2024-03-01", sma: 100.0 },
+      { timestamp: "2024-03-02", sma: 100.5, ema: 99.7 }
+    ];
+    const result = loadStaticIndicatorData(fixture);
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({ sma: 100.5, ema: 99.7 });
   });
 });

--- a/libs/indy-charts/api/static.spec.ts
+++ b/libs/indy-charts/api/static.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { loadStaticQuotes, loadStaticIndicatorData } from "./static";
+import { loadStaticQuotes, loadStaticIndicatorData, type RawQuote } from "./static";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -62,6 +62,18 @@ describe("loadStaticQuotes", () => {
     expect(result).toHaveLength(3);
     expect(result[0].close).toBe(50);
     expect(result[2].close).toBe(70);
+  });
+
+  it("accepts an explicit RawQuote[] fixture", () => {
+    const fixture: RawQuote[] = [
+      { timestamp: "2024-02-01T00:00:00Z", open: 1, high: 2, low: 0, close: 1.5, volume: 10 },
+      { timestamp: new Date("2024-02-02T00:00:00Z"), open: 2, high: 3, low: 1, close: 2.5, volume: 20 }
+    ];
+    const result = loadStaticQuotes(fixture);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].timestamp.toISOString()).toBe("2024-02-01T00:00:00.000Z");
+    expect(result[1].timestamp.toISOString()).toBe("2024-02-02T00:00:00.000Z");
   });
 });
 

--- a/libs/indy-charts/api/static.spec.ts
+++ b/libs/indy-charts/api/static.spec.ts
@@ -115,4 +115,16 @@ describe("loadStaticIndicatorData", () => {
     expect(result).toHaveLength(2);
     expect(result[1]).toMatchObject({ sma: 100.5, ema: 99.7 });
   });
+
+  it("preserves the deprecated `date` alias for v2 fixtures", () => {
+    const fixture: RawIndicatorRow[] = [
+      { date: "2024-03-01", sma: 100.0 },
+      { date: "2024-03-02", sma: 100.5, ema: 99.7 }
+    ];
+    const result = loadStaticIndicatorData(fixture);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ date: "2024-03-01", sma: 100.0 });
+    expect(result[1]).toMatchObject({ date: "2024-03-02", sma: 100.5, ema: 99.7 });
+  });
 });

--- a/libs/indy-charts/api/static.spec.ts
+++ b/libs/indy-charts/api/static.spec.ts
@@ -117,15 +117,4 @@ describe("loadStaticIndicatorData", () => {
     expect(result[1]).toMatchObject({ sma: 100.5, ema: 99.7 });
   });
 
-  it("preserves the deprecated `date` alias for v2 fixtures", () => {
-    const fixture: IndicatorDataRow[] = [
-      { date: "2024-03-01", sma: 100.0 },
-      { date: "2024-03-02", sma: 100.5, ema: 99.7 }
-    ];
-    const result = loadStaticIndicatorData(fixture);
-
-    expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ date: "2024-03-01", sma: 100.0 });
-    expect(result[1]).toMatchObject({ date: "2024-03-02", sma: 100.5, ema: 99.7 });
-  });
 });

--- a/libs/indy-charts/api/static.ts
+++ b/libs/indy-charts/api/static.ts
@@ -6,8 +6,8 @@ import { type Quote, type IndicatorDataRow } from "../config/types";
  * (per the `Quote.timestamp: Date | string` contract) and returns a new
  * array with timestamps normalized to `Date` instances.
  */
-export function loadStaticQuotes(raw: Quote[]): Quote[] {
-  return raw.map((q, index) => ({
+export function loadStaticQuotes(quotes: Quote[]): Quote[] {
+  return quotes.map((q, index) => ({
     timestamp: normalizeTimestamp(q.timestamp, index),
     open: q.open,
     high: q.high,

--- a/libs/indy-charts/api/static.ts
+++ b/libs/indy-charts/api/static.ts
@@ -38,8 +38,7 @@ function parseTimestamp(value: string, index: number): Date {
 /**
  * Load static indicator data synchronously (for VitePress SSG or build-time
  * rendering). Pass-through helper — `IndicatorDataRow[]` rows are already in
- * the shape downstream transformers expect (they handle the `timestamp` /
- * deprecated `date` alias).
+ * the shape downstream transformers expect.
  */
 export function loadStaticIndicatorData(data: IndicatorDataRow[]): IndicatorDataRow[] {
   return data;

--- a/libs/indy-charts/api/static.ts
+++ b/libs/indy-charts/api/static.ts
@@ -1,19 +1,25 @@
 import { type Quote, type IndicatorDataRow } from "../config/types";
 
 /**
+ * Raw input shape accepted by {@link loadStaticQuotes}. Timestamps may be
+ * either ISO 8601 strings or `Date` instances; everything else is OHLCV
+ * numbers. Use this when typing static fixture arrays for bring-your-own-data
+ * pages so the fixture type and the loader signature stay in lockstep.
+ */
+export interface RawQuote {
+  timestamp: string | Date;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+/**
  * Load static quote data synchronously (for VitePress SSG or build-time rendering).
  * Accepts objects with ISO 8601 string or Date timestamps and normalizes them to Date objects.
  */
-export function loadStaticQuotes(
-  raw: Array<{
-    timestamp: string | Date;
-    open: number;
-    high: number;
-    low: number;
-    close: number;
-    volume: number;
-  }>
-): Quote[] {
+export function loadStaticQuotes(raw: RawQuote[]): Quote[] {
   return raw.map((q, index) => ({
     timestamp: normalizeTimestamp(q.timestamp, index),
     open: q.open,

--- a/libs/indy-charts/api/static.ts
+++ b/libs/indy-charts/api/static.ts
@@ -49,9 +49,22 @@ function parseTimestamp(value: string, index: number): Date {
 }
 
 /**
+ * Raw input shape accepted by {@link loadStaticIndicatorData}. Each row
+ * carries a timestamp (ISO string or `Date`) and an arbitrary set of
+ * indicator result fields keyed by the indicator's `dataName`. The library
+ * does not transform these rows — they pass through to chart datasets as-is.
+ */
+export interface RawIndicatorRow {
+  timestamp?: string | Date;
+  /** @deprecated Skender v2 field name — accepted for backward compatibility */
+  date?: string;
+  [key: string]: unknown;
+}
+
+/**
  * Load static indicator data synchronously (for VitePress SSG or build-time rendering).
  * Passes through data as-is since indicator results are already in the correct format.
  */
-export function loadStaticIndicatorData(data: unknown[]): IndicatorDataRow[] {
-  return data as IndicatorDataRow[];
+export function loadStaticIndicatorData(data: RawIndicatorRow[]): IndicatorDataRow[] {
+  return data as unknown as IndicatorDataRow[];
 }

--- a/libs/indy-charts/api/static.ts
+++ b/libs/indy-charts/api/static.ts
@@ -1,25 +1,12 @@
 import { type Quote, type IndicatorDataRow } from "../config/types";
 
 /**
- * Raw input shape accepted by {@link loadStaticQuotes}. Timestamps may be
- * either ISO 8601 strings or `Date` instances; everything else is OHLCV
- * numbers. Use this when typing static fixture arrays for bring-your-own-data
- * pages so the fixture type and the loader signature stay in lockstep.
+ * Load static quote data synchronously (for VitePress SSG or build-time
+ * rendering). Accepts `Quote[]` with either ISO string or `Date` timestamps
+ * (per the `Quote.timestamp: Date | string` contract) and returns a new
+ * array with timestamps normalized to `Date` instances.
  */
-export interface RawQuote {
-  timestamp: string | Date;
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-  volume: number;
-}
-
-/**
- * Load static quote data synchronously (for VitePress SSG or build-time rendering).
- * Accepts objects with ISO 8601 string or Date timestamps and normalizes them to Date objects.
- */
-export function loadStaticQuotes(raw: RawQuote[]): Quote[] {
+export function loadStaticQuotes(raw: Quote[]): Quote[] {
   return raw.map((q, index) => ({
     timestamp: normalizeTimestamp(q.timestamp, index),
     open: q.open,
@@ -30,7 +17,7 @@ export function loadStaticQuotes(raw: RawQuote[]): Quote[] {
   }));
 }
 
-function normalizeTimestamp(value: string | Date, index: number): Date {
+function normalizeTimestamp(value: Date | string, index: number): Date {
   if (value instanceof Date) {
     if (Number.isNaN(value.getTime())) {
       throw new Error(`Invalid timestamp at index ${index}: "${value.toString()}"`);
@@ -49,22 +36,11 @@ function parseTimestamp(value: string, index: number): Date {
 }
 
 /**
- * Raw input shape accepted by {@link loadStaticIndicatorData}. Each row
- * carries a timestamp (ISO string or `Date`) and an arbitrary set of
- * indicator result fields keyed by the indicator's `dataName`. The library
- * does not transform these rows — they pass through to chart datasets as-is.
+ * Load static indicator data synchronously (for VitePress SSG or build-time
+ * rendering). Pass-through helper — `IndicatorDataRow[]` rows are already in
+ * the shape downstream transformers expect (they handle the `timestamp` /
+ * deprecated `date` alias).
  */
-export interface RawIndicatorRow {
-  timestamp?: string | Date;
-  /** @deprecated Skender v2 field name — accepted for backward compatibility */
-  date?: string;
-  [key: string]: unknown;
-}
-
-/**
- * Load static indicator data synchronously (for VitePress SSG or build-time rendering).
- * Passes through data as-is since indicator results are already in the correct format.
- */
-export function loadStaticIndicatorData(data: RawIndicatorRow[]): IndicatorDataRow[] {
-  return data as unknown as IndicatorDataRow[];
+export function loadStaticIndicatorData(data: IndicatorDataRow[]): IndicatorDataRow[] {
+  return data;
 }

--- a/libs/indy-charts/charts/chart-manager.spec.ts
+++ b/libs/indy-charts/charts/chart-manager.spec.ts
@@ -274,7 +274,7 @@ function makeSelection(listing: IndicatorListing, ucid: string): IndicatorSelect
 
 function makeIndicatorData(quotes: Quote[]): IndicatorDataRow[] {
   return quotes.map((q, index) => ({
-    timestamp: q.timestamp.toISOString(),
+    timestamp: new Date(q.timestamp).toISOString(),
     candle: q,
     sma: q.close * 0.99,
     rsi: 50 + (index % 10) // Deterministic value derived from index, not Math.random()

--- a/libs/indy-charts/charts/oscillator-chart.ts
+++ b/libs/indy-charts/charts/oscillator-chart.ts
@@ -16,6 +16,12 @@ import {
 } from "../config/types";
 
 export class OscillatorChart {
+  /**
+   * Underlying Chart.js instance. Read-only access (theme tweaks, dataset
+   * inspection) is supported. **Do not call `chart.destroy()` directly** — use
+   * {@link OscillatorChart.destroy} so library-level state (threshold dataset
+   * caches, legend annotations) is released alongside the Chart.js teardown.
+   */
   chart: Chart | undefined;
   private fullThresholdDatasets: IndicatorDataset[] = [];
 
@@ -167,6 +173,12 @@ export class OscillatorChart {
     this.chart.update("resize");
   }
 
+  /**
+   * Tear down this OscillatorChart and its underlying Chart.js instance.
+   * Releases threshold dataset caches, legend annotations, and the canvas
+   * binding. Always call this from your component's unmount hook — not
+   * `chart.destroy()`, which leaves library-level state orphaned.
+   */
   destroy(): void {
     if (this.chart) {
       this.chart.destroy();

--- a/libs/indy-charts/charts/oscillator-chart.ts
+++ b/libs/indy-charts/charts/oscillator-chart.ts
@@ -17,7 +17,7 @@ import {
 
 export class OscillatorChart {
   /**
-   * Underlying Chart.js instance. Read-only access (theme tweaks, dataset
+   * Underlying Chart.js instance. Read access (theme tweaks, dataset
    * inspection) is supported. **Do not call `chart.destroy()` directly** — use
    * {@link OscillatorChart.destroy} so library-level state (threshold dataset
    * caches, legend annotations) is released alongside the Chart.js teardown.
@@ -175,8 +175,8 @@ export class OscillatorChart {
 
   /**
    * Tear down this OscillatorChart and its underlying Chart.js instance.
-   * Releases threshold dataset caches, legend annotations, and the canvas
-   * binding. Always call this from your component's unmount hook — not
+   * Releases the cached threshold datasets and the Chart.js canvas binding.
+   * Always call this from your component's unmount hook — not
    * `chart.destroy()`, which leaves library-level state orphaned.
    */
   destroy(): void {
@@ -184,6 +184,7 @@ export class OscillatorChart {
       this.chart.destroy();
       this.chart = undefined;
     }
+    this.fullThresholdDatasets = [];
   }
 
   private configureThresholds(

--- a/libs/indy-charts/charts/oscillator-chart.ts
+++ b/libs/indy-charts/charts/oscillator-chart.ts
@@ -16,14 +16,19 @@ import {
 } from "../config/types";
 
 export class OscillatorChart {
+  private _chart: Chart | undefined;
+  private fullThresholdDatasets: IndicatorDataset[] = [];
+
   /**
-   * Underlying Chart.js instance. Read access (theme tweaks, dataset
-   * inspection) is supported. **Do not call `chart.destroy()` directly** — use
+   * Underlying Chart.js instance. Exposed read-only — assigning to this field
+   * is a TypeScript error. Read access (theme tweaks, dataset inspection) is
+   * supported. **Do not call `chart.destroy()` directly** — use
    * {@link OscillatorChart.destroy} so library-level state (threshold dataset
    * caches, legend annotations) is released alongside the Chart.js teardown.
    */
-  chart: Chart | undefined;
-  private fullThresholdDatasets: IndicatorDataset[] = [];
+  get chart(): Chart | undefined {
+    return this._chart;
+  }
 
   constructor(
     private readonly ctx: CanvasRenderingContext2D | HTMLCanvasElement,
@@ -50,37 +55,37 @@ export class OscillatorChart {
     });
 
     // Create chart
-    if (this.chart) this.chart.destroy();
-    this.chart = new Chart(this.ctx, chartConfig);
+    if (this._chart) this._chart.destroy();
+    this._chart = new Chart(this.ctx, chartConfig);
 
     // Add legend (after scales are drawn)
-    this.chart.update("none");
+    this._chart.update("none");
     this.updateLegend(selection);
-    this.chart.update("none");
+    this._chart.update("none");
   }
 
   updateLegend(selection: IndicatorSelection): void {
-    if (!this.chart) return;
+    if (!this._chart) return;
 
-    if (!this.chart.scales["x"] || !this.chart.scales["y"]) return;
-    const xPos: ScaleValue = this.chart.scales["x"].min;
-    const yPos: ScaleValue = this.chart.scales["y"].max;
+    if (!this._chart.scales["x"] || !this._chart.scales["y"]) return;
+    const xPos: ScaleValue = this._chart.scales["x"].min;
+    const yPos: ScaleValue = this._chart.scales["y"].max;
 
     const annotation = commonLegendAnnotation(selection.label, xPos, yPos, 1, this.settings);
 
-    if (this.chart.options?.plugins?.annotation) {
-      this.chart.options.plugins.annotation.annotations = { annotation };
+    if (this._chart.options?.plugins?.annotation) {
+      this._chart.options.plugins.annotation.annotations = { annotation };
     }
   }
 
   updateTheme(settings: ChartSettings): void {
     this.settings = settings;
-    if (!this.chart) return;
+    if (!this._chart) return;
 
     // Preserve theme-specific runtime options from render() that must persist
     // across theme changes (tooltip filter for thresholds, y-axis suggested bounds)
     const newOptions = baseOscillatorOptions(settings);
-    const existingOptions = this.chart.options;
+    const existingOptions = this._chart.options;
 
     // Preserve tooltip filter (filters out threshold datasets from tooltips)
     if (existingOptions?.plugins?.tooltip?.filter && newOptions.plugins?.tooltip) {
@@ -98,8 +103,8 @@ export class OscillatorChart {
       newY.suggestedMax = existingY.suggestedMax;
     }
 
-    this.chart.options = newOptions;
-    this.chart.update("none");
+    this._chart.options = newOptions;
+    this._chart.update("none");
   }
 
   /**
@@ -112,12 +117,12 @@ export class OscillatorChart {
   ): void {
     // Slice threshold datasets (inserted before selection datasets in render)
     this.fullThresholdDatasets.forEach((fullDataset, i) => {
-      if (!this.chart?.data.datasets[i]) return;
+      if (!this._chart?.data.datasets[i]) return;
       if (fullDataset.data && Array.isArray(fullDataset.data)) {
-        this.chart.data.datasets[i].data = [...fullDataset.data.slice(startIndex)];
+        this._chart.data.datasets[i].data = [...fullDataset.data.slice(startIndex)];
       }
       if (fullDataset.backgroundColor && Array.isArray(fullDataset.backgroundColor)) {
-        this.chart.data.datasets[i].backgroundColor = [
+        this._chart.data.datasets[i].backgroundColor = [
           ...(fullDataset.backgroundColor as string[]).slice(startIndex)
         ];
       }
@@ -156,21 +161,21 @@ export class OscillatorChart {
       }
     });
 
-    if (!this.chart) return;
+    if (!this._chart) return;
 
     // Two-pass update: first pass applies sliced data and recalculates scale
     // bounds; second pass renders the legend annotations (which read the fresh
     // scales from the first pass). Collapsing to one pass would leave
     // annotation positions stale.
-    this.chart.update("none");
+    this._chart.update("none");
     this.updateLegend(selection);
-    this.chart.update("none");
+    this._chart.update("none");
   }
 
   resize(): void {
-    if (!this.chart) return;
-    this.chart.resize();
-    this.chart.update("resize");
+    if (!this._chart) return;
+    this._chart.resize();
+    this._chart.update("resize");
   }
 
   /**
@@ -180,9 +185,9 @@ export class OscillatorChart {
    * `chart.destroy()`, which leaves library-level state orphaned.
    */
   destroy(): void {
-    if (this.chart) {
-      this.chart.destroy();
-      this.chart = undefined;
+    if (this._chart) {
+      this._chart.destroy();
+      this._chart = undefined;
     }
     this.fullThresholdDatasets = [];
   }

--- a/libs/indy-charts/charts/overlay-chart.ts
+++ b/libs/indy-charts/charts/overlay-chart.ts
@@ -26,7 +26,7 @@ const CHART_TYPES = {
 
 export class OverlayChart {
   /**
-   * Underlying Chart.js instance. Read-only access (theme tweaks, dataset
+   * Underlying Chart.js instance. Read access (theme tweaks, dataset
    * inspection) is supported. **Do not call `chart.destroy()` directly** — use
    * {@link OverlayChart.destroy} so library-level state (legend selections,
    * volume-axis cache) is released alongside the Chart.js teardown.
@@ -209,14 +209,16 @@ export class OverlayChart {
 
   /**
    * Tear down this OverlayChart and its underlying Chart.js instance. Releases
-   * theme observers, legend caches, and the canvas binding. Always call this
-   * from your component's unmount hook — not `chart.destroy()`, which leaves
-   * library-level state orphaned.
+   * the cached legend selections, the volume-axis cache, and the Chart.js
+   * canvas binding. Always call this from your component's unmount hook — not
+   * `chart.destroy()`, which leaves library-level state orphaned.
    */
   destroy(): void {
     if (this.chart) {
       this.chart.destroy();
       this.chart = undefined;
     }
+    this._latestLegendSelections = [];
+    this.volumeAxisSize = 0;
   }
 }

--- a/libs/indy-charts/charts/overlay-chart.ts
+++ b/libs/indy-charts/charts/overlay-chart.ts
@@ -25,6 +25,12 @@ const CHART_TYPES = {
 } as const;
 
 export class OverlayChart {
+  /**
+   * Underlying Chart.js instance. Read-only access (theme tweaks, dataset
+   * inspection) is supported. **Do not call `chart.destroy()` directly** — use
+   * {@link OverlayChart.destroy} so library-level state (legend selections,
+   * volume-axis cache) is released alongside the Chart.js teardown.
+   */
   chart: Chart | undefined;
   private volumeAxisSize = 0;
   private _latestLegendSelections: IndicatorSelection[] = [];
@@ -201,6 +207,12 @@ export class OverlayChart {
     this.chart.update("resize");
   }
 
+  /**
+   * Tear down this OverlayChart and its underlying Chart.js instance. Releases
+   * theme observers, legend caches, and the canvas binding. Always call this
+   * from your component's unmount hook — not `chart.destroy()`, which leaves
+   * library-level state orphaned.
+   */
   destroy(): void {
     if (this.chart) {
       this.chart.destroy();

--- a/libs/indy-charts/charts/overlay-chart.ts
+++ b/libs/indy-charts/charts/overlay-chart.ts
@@ -25,15 +25,20 @@ const CHART_TYPES = {
 } as const;
 
 export class OverlayChart {
+  private _chart: Chart | undefined;
+  private volumeAxisSize = 0;
+  private _latestLegendSelections: IndicatorSelection[] = [];
+
   /**
-   * Underlying Chart.js instance. Read access (theme tweaks, dataset
-   * inspection) is supported. **Do not call `chart.destroy()` directly** — use
+   * Underlying Chart.js instance. Exposed read-only — assigning to this field
+   * is a TypeScript error. Read access (theme tweaks, dataset inspection) is
+   * supported. **Do not call `chart.destroy()` directly** — use
    * {@link OverlayChart.destroy} so library-level state (legend selections,
    * volume-axis cache) is released alongside the Chart.js teardown.
    */
-  chart: Chart | undefined;
-  private volumeAxisSize = 0;
-  private _latestLegendSelections: IndicatorSelection[] = [];
+  get chart(): Chart | undefined {
+    return this._chart;
+  }
 
   constructor(
     private readonly ctx: CanvasRenderingContext2D | HTMLCanvasElement,
@@ -75,8 +80,8 @@ export class OverlayChart {
       };
     }
 
-    if (this.chart) this.chart.destroy();
-    this.chart = new Chart(this.ctx, chartConfig);
+    if (this._chart) this._chart.destroy();
+    this._chart = new Chart(this.ctx, chartConfig);
 
     // Return deep copy of datasets for dynamic slicing (structuredClone preserves NaN)
     return structuredClone(chartData.datasets);
@@ -98,48 +103,48 @@ export class OverlayChart {
   }
 
   addIndicatorDatasets(results: IndicatorResult[]): void {
-    if (!this.chart) return;
-    const chart = this.chart;
+    if (!this._chart) return;
+    const chart = this._chart;
     results.forEach((r: IndicatorResult) => {
       chart.data.datasets.push(r.dataset);
     });
-    this.chart.update("none");
+    this._chart.update("none");
   }
 
   removeIndicatorDatasets(results: IndicatorResult[]): void {
-    if (!this.chart) return;
-    const chart = this.chart;
+    if (!this._chart) return;
+    const chart = this._chart;
     results.forEach((result: IndicatorResult) => {
       const dx = chart.data.datasets.indexOf(result.dataset, 0);
       if (dx !== -1) {
         chart.data.datasets.splice(dx, 1);
       }
     });
-    this.chart.update("none");
+    this._chart.update("none");
   }
 
   updateLegends(overlaySelections: IndicatorSelection[]): void {
-    if (!this.chart) return;
-    if (!this.chart.scales["x"] || !this.chart.scales["y"]) return;
+    if (!this._chart) return;
+    if (!this._chart.scales["x"] || !this._chart.scales["y"]) return;
 
     this._latestLegendSelections = overlaySelections;
     this._applyLegendAnnotations();
   }
 
   private _applyLegendAnnotations(): void {
-    if (!this.chart) return;
-    if (!this.chart.scales["x"] || !this.chart.scales["y"]) return;
+    if (!this._chart) return;
+    if (!this._chart.scales["x"] || !this._chart.scales["y"]) return;
 
-    const xPos: ScaleValue = this.chart.scales["x"].min;
-    const yPos: ScaleValue = this.chart.scales["y"].max;
+    const xPos: ScaleValue = this._chart.scales["x"].min;
+    const yPos: ScaleValue = this._chart.scales["y"].max;
     let adjY = 10;
 
     const sorted = [...this._latestLegendSelections]
       .filter(x => x.chartType === CHART_TYPES.OVERLAY)
       .sort((a, b) => a.label.localeCompare(b.label));
 
-    if (this.chart.options?.plugins?.annotation) {
-      this.chart.options.plugins.annotation.annotations = sorted
+    if (this._chart.options?.plugins?.annotation) {
+      this._chart.options.plugins.annotation.annotations = sorted
         .filter(selection => selection.results.length > 0 && selection.results[0] !== undefined)
         .map((selection: IndicatorSelection, index: number) => {
           const annotation = commonLegendAnnotation(
@@ -154,38 +159,38 @@ export class OverlayChart {
           adjY += 15; // LEGEND_Y_OFFSET
           return annotation;
         });
-      this.chart.update("none");
+      this._chart.update("none");
     }
   }
 
   updateTheme(settings: ChartSettings): void {
     this.settings = settings;
-    if (!this.chart) return;
+    if (!this._chart) return;
 
     applyFinancialElementTheme(getFinancialPalette(settings.isDarkTheme ? "dark" : "light"));
 
-    this.chart.options = buildFinancialChartOptions(
+    this._chart.options = buildFinancialChartOptions(
       baseOverlayOptions(this.volumeAxisSize, settings)
     );
-    this.chart.update("none");
+    this._chart.update("none");
   }
 
   /**
    * Apply sliced datasets from pre-computed full datasets.
    */
   applySlicedData(fullMainDatasets: ChartDataset[], startIndex: number): void {
-    if (!this.chart) return;
+    if (!this._chart) return;
 
     // Price dataset (candlestick - index 0)
     const fullPrice = fullMainDatasets[0];
-    const currentPrice = this.chart.data.datasets[0];
+    const currentPrice = this._chart.data.datasets[0];
     if (fullPrice && currentPrice && fullPrice.type === "candlestick") {
       currentPrice.data = [...fullPrice.data.slice(startIndex)];
     }
 
     // Volume dataset (bar - index 1)
     const fullVolume = fullMainDatasets[1];
-    const currentVolume = this.chart.data.datasets[1];
+    const currentVolume = this._chart.data.datasets[1];
     if (fullVolume && currentVolume && fullVolume.type === "bar") {
       currentVolume.data = [...fullVolume.data.slice(startIndex)];
       if (fullVolume.backgroundColor && Array.isArray(fullVolume.backgroundColor)) {
@@ -198,13 +203,13 @@ export class OverlayChart {
     // Match OscillatorChart.applySlicedData which also uses "none" — both charts
     // share the same setBarCount() trigger, so they must update with identical
     // semantics to avoid one snapping while the other transitions.
-    this.chart.update("none");
+    this._chart.update("none");
   }
 
   resize(): void {
-    if (!this.chart) return;
-    this.chart.resize();
-    this.chart.update("resize");
+    if (!this._chart) return;
+    this._chart.resize();
+    this._chart.update("resize");
   }
 
   /**
@@ -214,9 +219,9 @@ export class OverlayChart {
    * `chart.destroy()`, which leaves library-level state orphaned.
    */
   destroy(): void {
-    if (this.chart) {
-      this.chart.destroy();
-      this.chart = undefined;
+    if (this._chart) {
+      this._chart.destroy();
+      this._chart = undefined;
     }
     this._latestLegendSelections = [];
     this.volumeAxisSize = 0;

--- a/libs/indy-charts/config/index.ts
+++ b/libs/indy-charts/config/index.ts
@@ -15,9 +15,6 @@ export type {
   Quote
 } from "./types";
 
-/** @deprecated Use Quote instead. */
-export type { Quote as RawQuote } from "./types";
-
 export type { ThemeColors } from "./theme-colors";
 
 export { baseChartOptions, defaultXAxisOptions, FONT_FAMILY } from "./common";

--- a/libs/indy-charts/config/types.ts
+++ b/libs/indy-charts/config/types.ts
@@ -24,8 +24,16 @@ export type ExtendedChartDataset = IndicatorDataset & {
   pointBorderColor?: string[];
 };
 
+/**
+ * Single source of truth for an OHLCV bar, mirroring the
+ * Skender.Stock.Indicators .NET `Quote` model. `timestamp` accepts either a
+ * `Date` instance or an ISO 8601 string so the same type works for in-memory
+ * data, JSON fixtures, and wire responses without a parallel "raw" type.
+ * The library normalizes to `Date` at consumption sites that need date
+ * arithmetic (see `data/transformers.ts`).
+ */
 export interface Quote {
-  timestamp: Date;
+  timestamp: Date | string;
   open: number;
   high: number;
   low: number;
@@ -33,12 +41,20 @@ export interface Quote {
   volume: number;
 }
 
+/**
+ * Indicator data row as returned by the API or supplied as a static fixture.
+ * Carries a timestamp (`timestamp` for Skender v3+; `date` is the v2 alias
+ * preserved for backward compatibility) and an arbitrary set of indicator
+ * result fields keyed by `dataName`. `candle` is populated on wire responses
+ * and consumed only by the CANDLESTICK_PATTERN category; fixtures for other
+ * indicators may omit it.
+ */
 export interface IndicatorDataRow {
   /** Skender.Stock.Indicators v3+ field name */
-  timestamp?: string;
+  timestamp?: Date | string;
   /** @deprecated Skender v2 field name — accepted for backward compatibility */
   date?: string;
-  candle: Quote;
+  candle?: Quote;
   [key: string]: unknown; // For dynamic indicator result values
 }
 

--- a/libs/indy-charts/config/types.ts
+++ b/libs/indy-charts/config/types.ts
@@ -43,17 +43,13 @@ export interface Quote {
 
 /**
  * Indicator data row as returned by the API or supplied as a static fixture.
- * Carries a timestamp (`timestamp` for Skender v3+; `date` is the v2 alias
- * preserved for backward compatibility) and an arbitrary set of indicator
+ * Carries a `timestamp` (string or Date) and an arbitrary set of indicator
  * result fields keyed by `dataName`. `candle` is populated on wire responses
  * and consumed only by the CANDLESTICK_PATTERN category; fixtures for other
  * indicators may omit it.
  */
 export interface IndicatorDataRow {
-  /** Skender.Stock.Indicators v3+ field name */
   timestamp?: Date | string;
-  /** @deprecated Skender v2 field name — accepted for backward compatibility */
-  date?: string;
   candle?: Quote;
   [key: string]: unknown; // For dynamic indicator result values
 }

--- a/libs/indy-charts/data/transformers.spec.ts
+++ b/libs/indy-charts/data/transformers.spec.ts
@@ -277,13 +277,13 @@ describe("buildDataPoints", () => {
     expect(pointRotation[0]).toBe(0);
   });
 
-  it("throws when a row has neither `timestamp` nor `date`", () => {
+  it("throws when a row is missing `timestamp`", () => {
     const data: IndicatorDataRow[] = [{ candle: makeQuote("2024-01-01"), sma: 50 }];
     const result = makeResult({ dataName: "sma" });
     const listing = makeListing();
 
     expect(() => buildDataPoints(data, result, listing)).toThrow(
-      /Indicator row missing both 'timestamp' and 'date' fields/
+      /Indicator row missing 'timestamp' field/
     );
   });
 

--- a/libs/indy-charts/data/transformers.ts
+++ b/libs/indy-charts/data/transformers.ts
@@ -79,16 +79,15 @@ export function buildDataPoints(
     if (typeof yValue !== "number") {
       yValue = NaN;
     }
-    const timestampSource = row.timestamp ?? row.date;
-    if (timestampSource == null) {
+    if (row.timestamp == null) {
       throw new Error(
-        `Indicator row missing both 'timestamp' and 'date' fields for "${result.dataName}"`
+        `Indicator row missing 'timestamp' field for "${result.dataName}"`
       );
     }
-    const x = new Date(timestampSource).valueOf();
+    const x = new Date(row.timestamp).valueOf();
     if (!Number.isFinite(x)) {
       throw new Error(
-        `Indicator row has invalid timestamp for "${result.dataName}": ${String(timestampSource)}`
+        `Indicator row has invalid timestamp for "${result.dataName}": ${String(row.timestamp)}`
       );
     }
     dataPoints.push({ x, y: yValue });

--- a/libs/indy-charts/data/transformers.ts
+++ b/libs/indy-charts/data/transformers.ts
@@ -57,8 +57,13 @@ export function buildDataPoints(
     const rawValue: unknown = row[result.dataName];
     let yValue = typeof rawValue === "number" ? rawValue : undefined;
 
-    // apply candle pointers
-    if (yValue !== undefined && listing.category === CATEGORIES.CANDLESTICK_PATTERN) {
+    // apply candle pointers (CANDLESTICK_PATTERN rows include a `candle` field
+    // from the API; skip the styling if a fixture-supplied row omits it)
+    if (
+      yValue !== undefined &&
+      listing.category === CATEGORIES.CANDLESTICK_PATTERN &&
+      row.candle
+    ) {
       const rawMatch = row["match"];
       const matchValue = typeof rawMatch === "number" ? rawMatch : 0;
       const candleConfig = getCandlePointConfiguration(matchValue, row.candle);

--- a/libs/indy-charts/index.ts
+++ b/libs/indy-charts/index.ts
@@ -142,7 +142,7 @@ export type { ChartManagerConfig } from "./charts";
 
 // API client
 export { createApiClient, loadStaticQuotes, loadStaticIndicatorData } from "./api";
-export type { ApiClient, ApiClientConfig } from "./api";
+export type { ApiClient, ApiClientConfig, RawQuote } from "./api";
 
 // Selection and sizing helpers
 export { applySelectionTokens, calculateOptimalBars, createDefaultSelection } from "./helpers";

--- a/libs/indy-charts/index.ts
+++ b/libs/indy-charts/index.ts
@@ -142,7 +142,7 @@ export type { ChartManagerConfig } from "./charts";
 
 // API client
 export { createApiClient, loadStaticQuotes, loadStaticIndicatorData } from "./api";
-export type { ApiClient, ApiClientConfig, RawIndicatorRow, RawQuote } from "./api";
+export type { ApiClient, ApiClientConfig } from "./api";
 
 // Selection and sizing helpers
 export { applySelectionTokens, calculateOptimalBars, createDefaultSelection } from "./helpers";

--- a/libs/indy-charts/index.ts
+++ b/libs/indy-charts/index.ts
@@ -85,8 +85,8 @@
  * ### API
  * - `createApiClient(config)` - Create a lightweight `fetch`-based `ApiClient`
  * - `ApiClient` - Interface exposing `getQuotes`, `getListings`, `getSelectionData`
- * - `loadStaticQuotes(raw)` - Normalize string/Date timestamps in static quote data
- * - `loadStaticIndicatorData(rows)` - Pass through indicator rows for SSG/static use
+ * - `loadStaticQuotes(quotes)` - Accept `Quote[]` (string or Date timestamps), return `Quote[]` with timestamps as Date
+ * - `loadStaticIndicatorData(rows)` - Pass-through helper for `IndicatorDataRow[]`
  *
  * ## Performance Considerations
  *

--- a/libs/indy-charts/index.ts
+++ b/libs/indy-charts/index.ts
@@ -142,7 +142,7 @@ export type { ChartManagerConfig } from "./charts";
 
 // API client
 export { createApiClient, loadStaticQuotes, loadStaticIndicatorData } from "./api";
-export type { ApiClient, ApiClientConfig, RawQuote } from "./api";
+export type { ApiClient, ApiClientConfig, RawIndicatorRow, RawQuote } from "./api";
 
 // Selection and sizing helpers
 export { applySelectionTokens, calculateOptimalBars, createDefaultSelection } from "./helpers";

--- a/libs/indy-charts/package.json
+++ b/libs/indy-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@facioquo/indy-charts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Framework-agnostic financial charting library with technical indicators and stock market data visualization",
   "author": "facioquo",
   "license": "Apache-2.0",

--- a/libs/indy-charts/vue/index.ts
+++ b/libs/indy-charts/vue/index.ts
@@ -5,6 +5,11 @@ import { StockIndicatorChart } from "./stock-indicator-chart";
 import type { IndyChartsVueOptions } from "./types";
 
 export { StockIndicatorChart } from "./stock-indicator-chart";
+export {
+  getTestIdPrefix,
+  slug,
+  STOCK_INDICATOR_CHART_TESTID_PREFIX
+} from "./slug";
 export type {
   IndyChartsVueApiOptions,
   IndyChartsVueDefaults,

--- a/libs/indy-charts/vue/slug.spec.ts
+++ b/libs/indy-charts/vue/slug.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+
+import { getTestIdPrefix, slug, STOCK_INDICATOR_CHART_TESTID_PREFIX } from "./slug";
+
+describe("slug", () => {
+  it("lowercases ASCII letters", () => {
+    expect(slug("HtTrendline")).toBe("httrendline");
+  });
+
+  it("collapses runs of non-alphanumeric chars to a single dash", () => {
+    expect(slug("BB(20, 2)")).toBe("bb-20-2");
+  });
+
+  it("trims leading and trailing dashes", () => {
+    expect(slug("  --foo--  ")).toBe("foo");
+  });
+
+  it("returns an empty string when input contains no alphanumeric chars", () => {
+    expect(slug("---")).toBe("");
+  });
+});
+
+describe("getTestIdPrefix", () => {
+  it("prepends the canonical chart prefix to the slugified id", () => {
+    expect(getTestIdPrefix("RSI")).toBe(`${STOCK_INDICATOR_CHART_TESTID_PREFIX}-rsi`);
+  });
+
+  it("matches the prefix the component emits on its root data-testid", () => {
+    expect(getTestIdPrefix("sma-fast")).toBe("stock-indicator-chart-sma-fast");
+  });
+});

--- a/libs/indy-charts/vue/slug.ts
+++ b/libs/indy-charts/vue/slug.ts
@@ -1,0 +1,31 @@
+/**
+ * Slugify a chart identifier the same way `<StockIndicatorChart>` derives its
+ * root element id and `data-testid` prefix. Use in tests, styles, or
+ * imperative DOM queries to ensure selector parity with the component output.
+ *
+ * @example
+ *   slug("HtTrendline"); // "httrendline"
+ *   slug("BB(20, 2)");   // "bb-20-2"
+ */
+export function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/** Prefix prepended to every `data-testid` on a `<StockIndicatorChart>` instance. */
+export const STOCK_INDICATOR_CHART_TESTID_PREFIX = "stock-indicator-chart";
+
+/**
+ * Compute the `data-testid` prefix `<StockIndicatorChart>` exposes for a given
+ * `id` or `indicator` value. Equivalent to
+ * `\`${STOCK_INDICATOR_CHART_TESTID_PREFIX}-${slug(idOrIndicator)}\`` — provided
+ * as a single helper so consumer tests don't reimplement the prefix string.
+ *
+ * @example
+ *   const root = page.locator(`[data-testid="${getTestIdPrefix("RSI")}-root"]`);
+ */
+export function getTestIdPrefix(idOrIndicator: string): string {
+  return `${STOCK_INDICATOR_CHART_TESTID_PREFIX}-${slug(idOrIndicator)}`;
+}

--- a/libs/indy-charts/vue/stock-indicator-chart.spec.ts
+++ b/libs/indy-charts/vue/stock-indicator-chart.spec.ts
@@ -174,6 +174,21 @@ describe("StockIndicatorChart", () => {
     app.unmount();
   });
 
+  it("tags author-facing errors with data-error-kind=\"author\"", async () => {
+    const root = createTestElement("root");
+    const app = renderer.createApp(StockIndicatorChart, { indicator: "rsi" });
+    // Intentionally omit provide() — triggers MISSING_SETUP_ERROR_MESSAGE, which is author-facing.
+
+    app.mount(root);
+    await nextTick();
+
+    const error = findByTestId(root, "stock-indicator-chart-rsi-error");
+    expect(error).toBeDefined();
+    expect(error?.props["data-error-kind"]).toBe("author");
+
+    app.unmount();
+  });
+
   it("renders a stable unavailable message for recoverable API failures", async () => {
     vi.stubGlobal(
       "fetch",
@@ -192,7 +207,49 @@ describe("StockIndicatorChart", () => {
         "Chart data is currently unavailable. Check the API service and try again."
       );
       expect(textContent(error!)).not.toContain("ECONNREFUSED");
+      expect(error?.props["data-error-kind"]).toBe("data");
     });
+
+    app.unmount();
+  });
+
+  it("uses the top-level id prop for the data-testid prefix", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => undefined))
+    );
+    const root = createTestElement("root");
+    const app = renderer.createApp(StockIndicatorChart, { indicator: "rsi", id: "rsi-fast" });
+    app.provide(indyChartsVueOptionsKey, defaultOptions);
+
+    app.mount(root);
+    await nextTick();
+
+    expect(findByTestId(root, "stock-indicator-chart-rsi-fast-root")).toBeDefined();
+    expect(findByTestId(root, "stock-indicator-chart-rsi-fast-loading")).toBeDefined();
+    expect(findByTestId(root, "stock-indicator-chart-rsi-root")).toBeUndefined();
+
+    app.unmount();
+  });
+
+  it("prefers the top-level id prop over config.id", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => undefined))
+    );
+    const root = createTestElement("root");
+    const app = renderer.createApp(StockIndicatorChart, {
+      indicator: "rsi",
+      id: "outer",
+      config: { id: "inner" }
+    });
+    app.provide(indyChartsVueOptionsKey, defaultOptions);
+
+    app.mount(root);
+    await nextTick();
+
+    expect(findByTestId(root, "stock-indicator-chart-outer-root")).toBeDefined();
+    expect(findByTestId(root, "stock-indicator-chart-inner-root")).toBeUndefined();
 
     app.unmount();
   });

--- a/libs/indy-charts/vue/stock-indicator-chart.spec.ts
+++ b/libs/indy-charts/vue/stock-indicator-chart.spec.ts
@@ -225,9 +225,30 @@ describe("StockIndicatorChart", () => {
     app.mount(root);
     await nextTick();
 
-    expect(findByTestId(root, "stock-indicator-chart-rsi-fast-root")).toBeDefined();
+    const rootSection = findByTestId(root, "stock-indicator-chart-rsi-fast-root");
+    expect(rootSection).toBeDefined();
+    expect(rootSection?.props["id"]).toBe("rsi-fast");
     expect(findByTestId(root, "stock-indicator-chart-rsi-fast-loading")).toBeDefined();
     expect(findByTestId(root, "stock-indicator-chart-rsi-root")).toBeUndefined();
+
+    app.unmount();
+  });
+
+  it("falls back to id=\"chart\" when id/config.id/indicator slugify to empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => undefined))
+    );
+    const root = createTestElement("root");
+    const app = renderer.createApp(StockIndicatorChart, { id: "---" });
+    app.provide(indyChartsVueOptionsKey, defaultOptions);
+
+    app.mount(root);
+    await nextTick();
+
+    const section = findByTestId(root, "stock-indicator-chart-chart-root");
+    expect(section).toBeDefined();
+    expect(section?.props["id"]).toBe("chart");
 
     app.unmount();
   });

--- a/libs/indy-charts/vue/stock-indicator-chart.ts
+++ b/libs/indy-charts/vue/stock-indicator-chart.ts
@@ -17,6 +17,7 @@ import type { IndicatorListing } from "../config";
 import { applySelectionTokens, createDefaultSelection } from "../helpers";
 import { setupIndyCharts } from "../setup";
 import { indyChartsVueOptionsKey } from "./context";
+import { slug, STOCK_INDICATOR_CHART_TESTID_PREFIX } from "./slug";
 import {
   chartSettingsFromOptions,
   type IndyChartsVueOptions,
@@ -28,13 +29,6 @@ const DEFAULT_BAR_COUNT = 250;
 const DATA_UNAVAILABLE_ERROR_MESSAGE =
   "Chart data is currently unavailable. Check the API service and try again.";
 const MISSING_SETUP_ERROR_MESSAGE = "setupIndyChartsForVue() has not been called.";
-
-function slug(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
-}
 
 function findListing(listings: IndicatorListing[], uiid: string): IndicatorListing | undefined {
   return listings.find(listing => listing.uiid.toLowerCase() === uiid.toLowerCase());
@@ -73,6 +67,10 @@ export const StockIndicatorChart = defineComponent({
       type: String,
       required: false
     },
+    id: {
+      type: String,
+      required: false
+    },
     config: {
       type: Object as PropType<StockIndicatorChartConfig>,
       required: false,
@@ -94,12 +92,15 @@ export const StockIndicatorChart = defineComponent({
   setup(props) {
     const options = inject<IndyChartsVueOptions>(indyChartsVueOptionsKey);
     const phase = ref<StockIndicatorChartPhase>("idle");
-    const errorMessage = ref("Chart data is unavailable.");
+    const errorMessage = ref(DATA_UNAVAILABLE_ERROR_MESSAGE);
+    const errorKind = ref<"author" | "data">("data");
     const chartType = ref<string>("overlay");
     const overlayCanvas = ref<HTMLCanvasElement | null>(null);
     const oscillatorCanvas = ref<HTMLCanvasElement | null>(null);
-    const rootId = computed(() => slug(props.config.id ?? props.indicator ?? "chart"));
-    const testIdPrefix = computed(() => `stock-indicator-chart-${rootId.value}`);
+    const rootId = computed(() =>
+      slug(props.id ?? props.config.id ?? props.indicator ?? "chart")
+    );
+    const testIdPrefix = computed(() => `${STOCK_INDICATOR_CHART_TESTID_PREFIX}-${rootId.value}`);
     const showOverlayCanvas = computed(
       () => chartType.value !== "oscillator" || props.withOverlay === true
     );
@@ -153,7 +154,8 @@ export const StockIndicatorChart = defineComponent({
       const token = ++loadToken;
       destroyChart();
       phase.value = "loading";
-      errorMessage.value = "Chart data is unavailable.";
+      errorMessage.value = DATA_UNAVAILABLE_ERROR_MESSAGE;
+      errorKind.value = "data";
 
       try {
         if (!options) {
@@ -245,9 +247,9 @@ export const StockIndicatorChart = defineComponent({
         if (disposed || token !== loadToken) return;
         destroyChart();
         phase.value = "error";
-        errorMessage.value = isAuthorFacingError(error)
-          ? error.message
-          : DATA_UNAVAILABLE_ERROR_MESSAGE;
+        const authorFacing = isAuthorFacingError(error);
+        errorMessage.value = authorFacing ? error.message : DATA_UNAVAILABLE_ERROR_MESSAGE;
+        errorKind.value = authorFacing ? "author" : "data";
       }
     }
 
@@ -349,7 +351,8 @@ export const StockIndicatorChart = defineComponent({
                 "div",
                 {
                   class: "indy-demo__status indy-demo__status--error",
-                  "data-testid": `${testIdPrefix.value}-error`
+                  "data-testid": `${testIdPrefix.value}-error`,
+                  "data-error-kind": errorKind.value
                 },
                 [
                   h("span", errorMessage.value),

--- a/libs/indy-charts/vue/stock-indicator-chart.ts
+++ b/libs/indy-charts/vue/stock-indicator-chart.ts
@@ -97,9 +97,10 @@ export const StockIndicatorChart = defineComponent({
     const chartType = ref<string>("overlay");
     const overlayCanvas = ref<HTMLCanvasElement | null>(null);
     const oscillatorCanvas = ref<HTMLCanvasElement | null>(null);
-    const rootId = computed(() =>
-      slug(props.id ?? props.config.id ?? props.indicator ?? "chart")
-    );
+    const rootId = computed(() => {
+      const normalized = slug(props.id ?? props.config.id ?? props.indicator ?? "chart");
+      return normalized || "chart";
+    });
     const testIdPrefix = computed(() => `${STOCK_INDICATOR_CHART_TESTID_PREFIX}-${rootId.value}`);
     const showOverlayCanvas = computed(
       () => chartType.value !== "oscillator" || props.withOverlay === true
@@ -309,7 +310,11 @@ export const StockIndicatorChart = defineComponent({
     return () =>
       h(
         "section",
-        { class: "indy-demo stock-indicator-chart", "data-testid": `${testIdPrefix.value}-root` },
+        {
+          id: rootId.value,
+          class: "indy-demo stock-indicator-chart",
+          "data-testid": `${testIdPrefix.value}-root`
+        },
         [
           phase.value === "loading"
             ? [

--- a/libs/indy-charts/vue/types.ts
+++ b/libs/indy-charts/vue/types.ts
@@ -45,10 +45,15 @@ export interface StockIndicatorChartProps {
   indicator?: string;
   /**
    * Stable identifier for this chart instance. Drives the root element id and
-   * the `data-testid` prefix (`stock-indicator-chart-<slug(id)>`). Overrides
-   * `config.id` and falls back to `indicator` when omitted. Use this to mount
-   * multiple instances of the same indicator on a single page with distinct
-   * test/CSS hooks.
+   * the `data-testid` prefix (`stock-indicator-chart-<slug(id)>`). Resolution
+   * order is `id` → `config.id` → `indicator`, with `undefined`/missing values
+   * skipped (an empty string is treated as a present value and slugified to
+   * the `"chart"` fallback). Use this to mount multiple instances of the same
+   * indicator on a single page with distinct test/CSS hooks. Treat as
+   * effectively set-once: the DOM `id`/`data-testid` updates immediately on
+   * change, but internal selection tokens are namespaced at chart-creation
+   * time and retain the previous prefix until the chart reloads for an
+   * unrelated reason.
    */
   id?: string;
   config?: StockIndicatorChartConfig;

--- a/libs/indy-charts/vue/types.ts
+++ b/libs/indy-charts/vue/types.ts
@@ -43,6 +43,14 @@ export interface IndyChartsVueOptions {
 
 export interface StockIndicatorChartProps {
   indicator?: string;
+  /**
+   * Stable identifier for this chart instance. Drives the root element id and
+   * the `data-testid` prefix (`stock-indicator-chart-<slug(id)>`). Overrides
+   * `config.id` and falls back to `indicator` when omitted. Use this to mount
+   * multiple instances of the same indicator on a single page with distinct
+   * test/CSS hooks.
+   */
+  id?: string;
   config?: StockIndicatorChartConfig;
   barCount?: number;
   withOverlay?: boolean;

--- a/tests/vitepress/examples/StaticChart.vue
+++ b/tests/vitepress/examples/StaticChart.vue
@@ -67,7 +67,7 @@ function buildEmaDataset(quotes: Quote[], period: number): ChartDataset<"line", 
 function renderChart(): void {
   if (!canvasEl.value) return;
   setupIndyCharts();
-  overlayChart?.chart?.destroy();
+  overlayChart?.destroy();
   overlayChart = new OverlayChart(canvasEl.value, {
     isDarkTheme: isDark(),
     showTooltips: false,
@@ -92,7 +92,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   observer?.disconnect();
   observer = null;
-  overlayChart?.chart?.destroy();
+  overlayChart?.destroy();
   overlayChart = null;
 });
 </script>

--- a/tests/vitepress/examples/custom-data.md
+++ b/tests/vitepress/examples/custom-data.md
@@ -20,9 +20,9 @@ The chart above plots OHLC + volume from a hard-coded `Quote[]` array, with an E
 
 ```typescript
 import { OverlayChart, loadStaticQuotes } from "@facioquo/indy-charts";
-import type { Quote } from "@facioquo/indy-charts";
+import type { RawQuote } from "@facioquo/indy-charts";
 
-const quotes: Quote[] = [
+const quotes: RawQuote[] = [
   { timestamp: "2025-01-02", open: 180.00, high: 182.50, low: 179.20, close: 181.80, volume: 38500000 },
   // ... more bars
 ];
@@ -96,14 +96,16 @@ import {
   OverlayChart,
   loadStaticQuotes,
   setupIndyCharts,
-  type Quote
+  type Quote,
+  type RawQuote
 } from "@facioquo/indy-charts";
 import type { ChartDataset, ScatterDataPoint } from "chart.js";
 
-const quotes: Quote[] = loadStaticQuotes([
+const rawQuotes: RawQuote[] = [
   { timestamp: "2025-01-02", open: 180.00, high: 182.50, low: 179.20, close: 181.80, volume: 38500000 },
   // ... more bars
-]);
+];
+const quotes: Quote[] = loadStaticQuotes(rawQuotes);
 
 function computeEma(closes: number[], period: number): number[] {
   if (!Number.isInteger(period) || period <= 0) {
@@ -184,12 +186,12 @@ onBeforeUnmount(() => {
 
 ## Key points
 
-- **`Quote`**: input shape with ISO string `timestamp` and numeric OHLCV fields
-- **`loadStaticQuotes`**: converts `timestamp` strings to `Date` objects, returning `Quote[]`
+- **`RawQuote`**: input shape with ISO string (or `Date`) `timestamp` and numeric OHLCV fields — type your fixture arrays as `RawQuote[]`
+- **`loadStaticQuotes`**: converts `RawQuote[]` to `Quote[]` (normalizes timestamps to `Date` objects)
 - **`OverlayChart`**: renders candlestick and volume directly onto a `<canvas>` element
 - **Custom indicators**: push your own `ChartDataset` onto `chart.data.datasets` after `render()`, then call `chart.update("none")`. Any Chart.js dataset shape works — line, dot, bar, etc.
 - **Theme sync**: re-create the chart on `document.documentElement` class changes to follow the page's dark / light mode automatically
-- **Cleanup**: always call `chart.destroy()` in the component's unmount hook
+- **Cleanup**: always call `chart.destroy()` (the wrapper) in the component's unmount hook — never `chart.chart?.destroy()` (Chart.js only), which leaks the wrapper's cached state
 
 ## Next steps
 

--- a/tests/vitepress/examples/custom-data.md
+++ b/tests/vitepress/examples/custom-data.md
@@ -12,7 +12,7 @@ Render a candlestick + volume chart **and** a technical indicator overlay direct
   <StaticChart />
 </ClientOnly>
 
-The chart above plots OHLC + volume from a hard-coded `RawQuote[]` array (normalized to `Quote[]` via `loadStaticQuotes`), with an EMA(20) line computed locally. Everything below ships in the page bundle — no network calls.
+The chart above plots OHLC + volume from a hard-coded `Quote[]` array (ISO string timestamps normalized to `Date` via `loadStaticQuotes`), with an EMA(20) line computed locally. Everything below ships in the page bundle — no network calls.
 
 ## How it works
 
@@ -20,13 +20,13 @@ The chart above plots OHLC + volume from a hard-coded `RawQuote[]` array (normal
 
 ```typescript
 import { OverlayChart, loadStaticQuotes } from "@facioquo/indy-charts";
-import type { Quote, RawQuote } from "@facioquo/indy-charts";
+import type { Quote } from "@facioquo/indy-charts";
 
-const rawQuotes: RawQuote[] = [
+// Quote.timestamp accepts ISO strings or Date instances.
+const quotes: Quote[] = loadStaticQuotes([
   { timestamp: "2025-01-02", open: 180.00, high: 182.50, low: 179.20, close: 181.80, volume: 38500000 },
   // ... more bars
-];
-const quotes: Quote[] = loadStaticQuotes(rawQuotes);
+]);
 
 const canvas = document.getElementById("my-canvas") as HTMLCanvasElement;
 const chart = new OverlayChart(canvas, { isDarkTheme: false, showTooltips: false });
@@ -97,16 +97,15 @@ import {
   OverlayChart,
   loadStaticQuotes,
   setupIndyCharts,
-  type Quote,
-  type RawQuote
+  type Quote
 } from "@facioquo/indy-charts";
 import type { ChartDataset, ScatterDataPoint } from "chart.js";
 
-const rawQuotes: RawQuote[] = [
+// Quote.timestamp accepts ISO strings or Date instances.
+const quotes: Quote[] = loadStaticQuotes([
   { timestamp: "2025-01-02", open: 180.00, high: 182.50, low: 179.20, close: 181.80, volume: 38500000 },
   // ... more bars
-];
-const quotes: Quote[] = loadStaticQuotes(rawQuotes);
+]);
 
 function computeEma(closes: number[], period: number): number[] {
   if (!Number.isInteger(period) || period <= 0) {
@@ -187,8 +186,8 @@ onBeforeUnmount(() => {
 
 ## Key points
 
-- **`RawQuote`**: input shape with ISO string (or `Date`) `timestamp` and numeric OHLCV fields — type your fixture arrays as `RawQuote[]`
-- **`loadStaticQuotes`**: converts `RawQuote[]` to `Quote[]` (normalizes timestamps to `Date` objects)
+- **`Quote`**: single OHLCV bar — `timestamp` accepts an ISO string or `Date` instance, the rest are numeric. Type your fixture arrays as `Quote[]`.
+- **`loadStaticQuotes`**: normalizes `Quote.timestamp` to a `Date` (no-op when already a Date)
 - **`OverlayChart`**: renders candlestick and volume directly onto a `<canvas>` element
 - **Custom indicators**: push your own `ChartDataset` onto `chart.data.datasets` after `render()`, then call `chart.update("none")`. Any Chart.js dataset shape works — line, dot, bar, etc.
 - **Theme sync**: re-create the chart on `document.documentElement` class changes to follow the page's dark / light mode automatically

--- a/tests/vitepress/examples/custom-data.md
+++ b/tests/vitepress/examples/custom-data.md
@@ -12,7 +12,7 @@ Render a candlestick + volume chart **and** a technical indicator overlay direct
   <StaticChart />
 </ClientOnly>
 
-The chart above plots OHLC + volume from a hard-coded `Quote[]` array, with an EMA(20) line computed locally. Everything below ships in the page bundle — no network calls.
+The chart above plots OHLC + volume from a hard-coded `RawQuote[]` array (normalized to `Quote[]` via `loadStaticQuotes`), with an EMA(20) line computed locally. Everything below ships in the page bundle — no network calls.
 
 ## How it works
 
@@ -20,19 +20,20 @@ The chart above plots OHLC + volume from a hard-coded `Quote[]` array, with an E
 
 ```typescript
 import { OverlayChart, loadStaticQuotes } from "@facioquo/indy-charts";
-import type { RawQuote } from "@facioquo/indy-charts";
+import type { Quote, RawQuote } from "@facioquo/indy-charts";
 
 const rawQuotes: RawQuote[] = [
   { timestamp: "2025-01-02", open: 180.00, high: 182.50, low: 179.20, close: 181.80, volume: 38500000 },
   // ... more bars
 ];
+const quotes: Quote[] = loadStaticQuotes(rawQuotes);
 
 const canvas = document.getElementById("my-canvas") as HTMLCanvasElement;
 const chart = new OverlayChart(canvas, { isDarkTheme: false, showTooltips: false });
-chart.render(loadStaticQuotes(rawQuotes));
+chart.render(quotes);
 
 // Push an EMA(20) line onto the existing chart.
-chart.chart?.data.datasets.push(buildEmaDataset(rawQuotes, 20));
+chart.chart?.data.datasets.push(buildEmaDataset(quotes, 20));
 chart.chart?.update("none");
 ```
 

--- a/tests/vitepress/examples/custom-data.md
+++ b/tests/vitepress/examples/custom-data.md
@@ -22,17 +22,17 @@ The chart above plots OHLC + volume from a hard-coded `Quote[]` array, with an E
 import { OverlayChart, loadStaticQuotes } from "@facioquo/indy-charts";
 import type { RawQuote } from "@facioquo/indy-charts";
 
-const quotes: RawQuote[] = [
+const rawQuotes: RawQuote[] = [
   { timestamp: "2025-01-02", open: 180.00, high: 182.50, low: 179.20, close: 181.80, volume: 38500000 },
   // ... more bars
 ];
 
 const canvas = document.getElementById("my-canvas") as HTMLCanvasElement;
 const chart = new OverlayChart(canvas, { isDarkTheme: false, showTooltips: false });
-chart.render(loadStaticQuotes(quotes));
+chart.render(loadStaticQuotes(rawQuotes));
 
 // Push an EMA(20) line onto the existing chart.
-chart.chart?.data.datasets.push(buildEmaDataset(quotes, 20));
+chart.chart?.data.datasets.push(buildEmaDataset(rawQuotes, 20));
 chart.chart?.update("none");
 ```
 

--- a/tests/vitepress/examples/custom-data.md
+++ b/tests/vitepress/examples/custom-data.md
@@ -149,7 +149,7 @@ function isDark() {
 function renderChart() {
   if (!canvasEl.value) return;
   setupIndyCharts();
-  overlayChart?.chart?.destroy();
+  overlayChart?.destroy();
   overlayChart = new OverlayChart(canvasEl.value, {
     isDarkTheme: isDark(),
     showTooltips: false,
@@ -172,7 +172,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   observer?.disconnect();
   observer = null;
-  overlayChart?.chart?.destroy();
+  overlayChart?.destroy();
   overlayChart = null;
 });
 </script>

--- a/tests/vitepress/examples/indicators.md
+++ b/tests/vitepress/examples/indicators.md
@@ -5,7 +5,7 @@ Oscillator indicators (RSI, MACD, Stochastic, etc.) render as a standalone chart
 ## Standalone oscillator
 
 <ClientOnly>
-  <StockIndicatorChart indicator="rsi" :config="{ id: 'rsi-standalone' }" />
+  <StockIndicatorChart indicator="rsi" id="rsi-standalone" />
 </ClientOnly>
 
 ::: code-group
@@ -52,7 +52,7 @@ manager.createOscillator(canvas, selection, listing);
 ## Oscillator paired with price chart
 
 <ClientOnly>
-  <StockIndicatorChart indicator="rsi" :with-overlay="true" :config="{ id: 'rsi-with-overlay' }" />
+  <StockIndicatorChart indicator="rsi" :with-overlay="true" id="rsi-with-overlay" />
 </ClientOnly>
 
 When paired, you need **two canvases** — one for the price/volume overlay and one for the oscillator panel below it.

--- a/tests/vitepress/examples/indicators.md
+++ b/tests/vitepress/examples/indicators.md
@@ -16,6 +16,9 @@ Oscillator indicators (RSI, MACD, Stochastic, etc.) render as a standalone chart
 </ClientOnly>
 ```
 
+> [!tip]
+> Add `id` prop for stable element identification in testing: `<StockIndicatorChart indicator="rsi" id="rsi-1" />`. This is optional but recommended for Playwright/E2E tests.
+
 ```html [Plain HTML]
 <canvas id="rsi-chart"></canvas>
 ```
@@ -64,6 +67,9 @@ When paired, you need **two canvases** — one for the price/volume overlay and 
   <StockIndicatorChart indicator="rsi" :with-overlay="true" />
 </ClientOnly>
 ```
+
+> [!tip]
+> Add `id` prop for stable element identification in testing: `<StockIndicatorChart indicator="rsi" :with-overlay="true" id="rsi-overlay" />`. This is optional but recommended for Playwright/E2E tests.
 
 ```html [Plain HTML]
 <canvas id="price-chart"></canvas>

--- a/tests/vitepress/examples/sample-quotes.ts
+++ b/tests/vitepress/examples/sample-quotes.ts
@@ -1,10 +1,11 @@
-import type { Quote } from "@facioquo/indy-charts";
+import type { RawQuote } from "@facioquo/indy-charts";
 
 /**
  * Forty synthetic daily OHLCV bars (Jan 2 – Feb 28, 2025).
- * Demonstrates the {@link Quote} shape expected by `loadStaticQuotes`.
+ * Typed as {@link RawQuote} — ISO string timestamps that `loadStaticQuotes`
+ * normalizes to `Date` objects.
  */
-export const SAMPLE_QUOTES: Quote[] = [
+export const SAMPLE_QUOTES: RawQuote[] = [
   { timestamp: "2025-01-02", open: 180.0, high: 182.5, low: 179.2, close: 181.8, volume: 38500000 },
   { timestamp: "2025-01-03", open: 181.8, high: 183.4, low: 180.5, close: 182.6, volume: 32100000 },
   { timestamp: "2025-01-06", open: 182.6, high: 184.2, low: 181.0, close: 183.4, volume: 29800000 },

--- a/tests/vitepress/examples/sample-quotes.ts
+++ b/tests/vitepress/examples/sample-quotes.ts
@@ -1,11 +1,11 @@
-import type { RawQuote } from "@facioquo/indy-charts";
+import type { Quote } from "@facioquo/indy-charts";
 
 /**
- * Forty synthetic daily OHLCV bars (Jan 2 – Feb 28, 2025).
- * Typed as {@link RawQuote} — ISO string timestamps that `loadStaticQuotes`
- * normalizes to `Date` objects.
+ * Forty synthetic daily OHLCV bars (Jan 2 – Feb 28, 2025). The fixture uses
+ * ISO string timestamps; `Quote.timestamp` is `Date | string`, and
+ * `loadStaticQuotes` normalizes to `Date` instances on consumption.
  */
-export const SAMPLE_QUOTES: RawQuote[] = [
+export const SAMPLE_QUOTES: Quote[] = [
   { timestamp: "2025-01-02", open: 180.0, high: 182.5, low: 179.2, close: 181.8, volume: 38500000 },
   { timestamp: "2025-01-03", open: 181.8, high: 183.4, low: 180.5, close: 182.6, volume: 32100000 },
   { timestamp: "2025-01-06", open: 182.6, high: 184.2, low: 181.0, close: 183.4, volume: 29800000 },

--- a/tests/vitepress/guide/installation.md
+++ b/tests/vitepress/guide/installation.md
@@ -61,7 +61,7 @@ If the chart renders, you're set. If not, check the browser console — most err
 | `ChartManager`, `OverlayChart`, `OscillatorChart` | High-level chart classes |
 | `createApiClient` | Typed REST client for quotes + indicators |
 | `loadStaticQuotes`, `loadStaticIndicatorData` | Use your own data, no API needed |
-| `RawQuote` (type) | Input shape for `loadStaticQuotes` — type fixture arrays as `RawQuote[]` |
+| `RawQuote`, `RawIndicatorRow` (types) | Input shapes for the static loaders — type fixture arrays explicitly |
 | `setupIndyCharts`, `setupIndyChartsForVue` | One-time registration of Chart.js controllers |
 | `getThemeColors`, `getFinancialPalette` | Theme + candlestick color helpers |
 

--- a/tests/vitepress/guide/installation.md
+++ b/tests/vitepress/guide/installation.md
@@ -61,7 +61,7 @@ If the chart renders, you're set. If not, check the browser console — most err
 | `ChartManager`, `OverlayChart`, `OscillatorChart` | High-level chart classes |
 | `createApiClient` | Typed REST client for quotes + indicators |
 | `loadStaticQuotes`, `loadStaticIndicatorData` | Use your own data, no API needed |
-| `RawQuote`, `RawIndicatorRow` (types) | Input shapes for the static loaders — type fixture arrays explicitly |
+| `Quote`, `IndicatorDataRow` (types) | Single source of truth shapes — `timestamp` accepts ISO string or `Date` |
 | `setupIndyCharts`, `setupIndyChartsForVue` | One-time registration of Chart.js controllers |
 | `getThemeColors`, `getFinancialPalette` | Theme + candlestick color helpers |
 

--- a/tests/vitepress/guide/installation.md
+++ b/tests/vitepress/guide/installation.md
@@ -61,6 +61,7 @@ If the chart renders, you're set. If not, check the browser console — most err
 | `ChartManager`, `OverlayChart`, `OscillatorChart` | High-level chart classes |
 | `createApiClient` | Typed REST client for quotes + indicators |
 | `loadStaticQuotes`, `loadStaticIndicatorData` | Use your own data, no API needed |
+| `RawQuote` (type) | Input shape for `loadStaticQuotes` — type fixture arrays as `RawQuote[]` |
 | `setupIndyCharts`, `setupIndyChartsForVue` | One-time registration of Chart.js controllers |
 | `getThemeColors`, `getFinancialPalette` | Theme + candlestick color helpers |
 

--- a/tests/vitepress/index.md
+++ b/tests/vitepress/index.md
@@ -55,19 +55,19 @@ features:
 A price chart with an EMA overlay:
 
 <ClientOnly>
-  <StockIndicatorChart indicator="ema" :config="{ id: 'home-ema-overlay' }" />
+  <StockIndicatorChart indicator="ema" id="home-ema-overlay" />
 </ClientOnly>
 
 A standalone RSI oscillator:
 
 <ClientOnly>
-  <StockIndicatorChart indicator="rsi" :config="{ id: 'home-rsi-standalone' }" />
+  <StockIndicatorChart indicator="rsi" id="home-rsi-standalone" />
 </ClientOnly>
 
 An oscillator paired with the price chart (`:with-overlay="true"`):
 
 <ClientOnly>
-  <StockIndicatorChart indicator="rsi" :with-overlay="true" :config="{ id: 'home-rsi-with-overlay' }" />
+  <StockIndicatorChart indicator="rsi" :with-overlay="true" id="home-rsi-with-overlay" />
 </ClientOnly>
 
 Each instance is independent and manages its own `ChartManager`. Drop as many as you want on a page.


### PR DESCRIPTION
## Summary

Originally five DX issues from migrating the [Stock.Indicators VitePress docs site](https://github.com/DaveSkender/Stock.Indicators/pull/2000) to `@facioquo/indy-charts@0.3.0`. During review the scope expanded to unify the library's data types around a single `Quote` source-of-truth (matching the .NET model) rather than introducing parallel \"raw\" types.

### Type unification

- `Quote.timestamp` is now `Date | string`. This matches the wire format (JSON deserializes timestamps as strings) and the existing consumption pattern (`new Date(q.timestamp).valueOf()` already accepts both, e.g. `data/transformers.ts:28`).
- `IndicatorDataRow.timestamp` is `Date | string | undefined`; `IndicatorDataRow.candle` is now optional (the API populates it, but fixtures for non-CANDLESTICK_PATTERN indicators legitimately omit it).
- The interim `RawQuote` and `RawIndicatorRow` interfaces (added earlier in this branch) were **deleted**. Consumers type fixture arrays as `Quote[]` / `IndicatorDataRow[]` directly. The original DX problem (lying about types with `Quote[]` when timestamps were strings) is solved by widening `Quote`, not by adding a parallel type.
- The deprecated `IndicatorDataRow.date` v2 alias was also dropped (per repo direction — this codebase isn't a third-party package with a community migration story).
- `@facioquo/chartjs-chart-financial`'s `QuoteLike` widened to match.

### Stronger typing kept

- `loadStaticIndicatorData(data: IndicatorDataRow[])` — was `unknown[]` pre-PR.
- `ApiClient.getSelectionData(): Promise<IndicatorDataRow[]>` — was `Promise<unknown[]>` pre-PR, with new `Array.isArray` validation on the response body.
- `OverlayChart.chart` / `OscillatorChart.chart` are getter-only public properties (`get chart(): Chart | undefined`). Assigning to them is a TypeScript error, nudging consumers toward `wrapper.destroy()`.

### Issue-by-issue resolution

- **#482** — Single `Quote` and `IndicatorDataRow` are the source of truth. The original ask (a public named input type) is satisfied by collapsing rather than splitting.
- **#483** — `data-error-kind=\"author\" | \"data\"` attribute on the error block; the template already rendered `errorMessage.value`. Phase split deferred.
- **#484** — `id?: string` is a first-class prop on `<StockIndicatorChart>`. Applied to both the root `<section>` element's `id` attribute and the `data-testid` prefix, with a `\"chart\"` fallback for empty slugs.
- **#485** — `slug`, `getTestIdPrefix`, and `STOCK_INDICATOR_CHART_TESTID_PREFIX` exported from `@facioquo/indy-charts/vue`.
- **#486** — JSDoc on `chart` and `destroy()`; `destroy()` implementations now actually clear cached wrapper state (`_latestLegendSelections`, `volumeAxisSize`, `fullThresholdDatasets`); `chart` is getter-only via a private `_chart` backing; README \"Teardown contract\" section; downstream BYOD examples updated.

### Doc-site updates

- `sample-quotes.ts` typed as `Quote[]` (legal with string timestamps — the original lying-type case).
- `custom-data.md` and `installation.md` walk through `Quote` only.
- `index.md`, `examples/indicators.md` switched to the top-level `id` prop, dropping the inline-config code smell.

Closes #482, #483, #484, #485, #486.

## Test plan

- [x] `pnpm --filter @facioquo/indy-charts run test` — 170/170 passing
- [x] `pnpm --filter @facioquo/chartjs-chart-financial run test` — 11/11 passing
- [x] `pnpm --filter @stock-charts/client run test` — 113/113 passing
- [x] `pnpm --filter @facioquo/indy-charts run build` — clean. Dist typings expose `Quote.timestamp: Date | string`, getter-only `chart`, typed loaders, typed API client.
- [x] `pnpm --filter @facioquo/indy-charts run lint` — clean
- [x] `pnpm --filter @facioquo/chartjs-chart-financial run lint` — clean
- [x] `pnpm --filter @stock-charts/client run lint --max-warnings=0` — clean
- [x] `pnpm --filter @stock-charts/client run build` — clean
- [x] `pnpm --filter @stock-charts/vitepress-example run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)