### PR TITLE
ci: add lint-and-test aggregator job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
           retention-days: 3
 
   lint-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [test-backend, test-libraries, test-website, test-e2e]
     if: always()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,3 +235,14 @@ jobs:
           name: playwright-report
           path: tests/playwright/playwright-report/
           retention-days: 3
+
+  lint-and-test:
+    runs-on: ubuntu-latest
+    needs: [test-backend, test-libraries, test-website, test-e2e]
+    if: always()
+    steps:
+      - name: Verify required jobs succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One or more required jobs did not succeed."
+          exit 1


### PR DESCRIPTION
Adds a `lint-and-test` aggregator job to `ci.yml` that `needs: [test-backend, test-libraries, test-website, test-e2e]` and fails if any does not succeed, satisfying the org ruleset requiring a `lint-and-test` status check. Existing jobs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)