### PR TITLE
feat: Compose overlay indicator with companion oscillator

### DIFF
--- a/libs/indy-charts/api/static.spec.ts
+++ b/libs/indy-charts/api/static.spec.ts
@@ -73,7 +73,14 @@ describe("loadStaticQuotes", () => {
   it("accepts a Quote[] fixture with mixed string/Date timestamps", () => {
     const fixture: Quote[] = [
       { timestamp: "2024-02-01T00:00:00Z", open: 1, high: 2, low: 0, close: 1.5, volume: 10 },
-      { timestamp: new Date("2024-02-02T00:00:00Z"), open: 2, high: 3, low: 1, close: 2.5, volume: 20 }
+      {
+        timestamp: new Date("2024-02-02T00:00:00Z"),
+        open: 2,
+        high: 3,
+        low: 1,
+        close: 2.5,
+        volume: 20
+      }
     ];
     const result = loadStaticQuotes(fixture);
 
@@ -116,5 +123,4 @@ describe("loadStaticIndicatorData", () => {
     expect(result).toHaveLength(2);
     expect(result[1]).toMatchObject({ sma: 100.5, ema: 99.7 });
   });
-
 });

--- a/libs/indy-charts/config/oscillator.spec.ts
+++ b/libs/indy-charts/config/oscillator.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { type Tick } from "chart.js";
+
+import { baseOscillatorOptions } from "./oscillator";
+import { type ChartSettings } from "./types";
+
+const settings: ChartSettings = { isDarkTheme: false, showTooltips: true };
+
+type TickCallback = (
+  value: string | number,
+  index: number,
+  ticks: Tick[]
+) => string | number | null;
+
+function yTickCallback(): TickCallback {
+  const options = baseOscillatorOptions(settings);
+  const y = options.scales?.["y"];
+  const callback = y && "ticks" in y ? y.ticks.callback : undefined;
+  if (typeof callback !== "function") {
+    throw new Error("y-axis tick callback is not configured");
+  }
+  return callback;
+}
+
+function ticks(count: number): Tick[] {
+  return Array.from({ length: count }, (_, i): Tick => ({ value: i }));
+}
+
+describe("baseOscillatorOptions", () => {
+  it("hides the x-axis", () => {
+    const options = baseOscillatorOptions(settings);
+    expect(options.scales?.["x"]?.display).toBe(false);
+  });
+
+  describe("y-axis tick callback", () => {
+    it("keeps boundary labels on short panes with few gridlines (issue #495)", () => {
+      const callback = yTickCallback();
+      const values = ticks(3);
+
+      // first and last labels must remain visible so the axis range is readable
+      expect(callback(0, 0, values)).not.toBeNull();
+      expect(callback(2, 2, values)).not.toBeNull();
+      expect(callback(1, 1, values)).not.toBeNull();
+    });
+
+    it("drops the first and last labels once enough gridlines exist", () => {
+      const callback = yTickCallback();
+      const values = ticks(6);
+
+      expect(callback(0, 0, values)).toBeNull();
+      expect(callback(5, 5, values)).toBeNull();
+      // interior labels remain
+      expect(callback(2, 2, values)).not.toBeNull();
+    });
+
+    it("condenses large values with magnitude suffixes", () => {
+      const callback = yTickCallback();
+      const values = ticks(6);
+
+      expect(callback(20_000_000, 2, values)).toBe("20M");
+      expect(callback(50_000, 3, values)).toBe("50K");
+    });
+  });
+});

--- a/libs/indy-charts/config/oscillator.spec.ts
+++ b/libs/indy-charts/config/oscillator.spec.ts
@@ -44,6 +44,17 @@ describe("baseOscillatorOptions", () => {
       expect(callback(1, 1, values)).not.toBeNull();
     });
 
+    it("drops the first and last labels at exactly the threshold (4 ticks)", () => {
+      const callback = yTickCallback();
+      const values = ticks(4);
+
+      expect(callback(0, 0, values)).toBeNull();
+      expect(callback(3, 3, values)).toBeNull();
+      // exactly two interior labels remain
+      expect(callback(1, 1, values)).not.toBeNull();
+      expect(callback(2, 2, values)).not.toBeNull();
+    });
+
     it("drops the first and last labels once enough gridlines exist", () => {
       const callback = yTickCallback();
       const values = ticks(6);

--- a/libs/indy-charts/config/oscillator.ts
+++ b/libs/indy-charts/config/oscillator.ts
@@ -3,6 +3,19 @@ import { type CartesianScaleOptions, type ChartConfiguration, type ChartOptions 
 import { type ChartSettings } from "./types";
 import { baseChartOptions } from "./common";
 
+/**
+ * Minimum number of y-axis ticks an oscillator pane must generate before the
+ * first and last (boundary) labels are dropped.
+ *
+ * The boundary labels are normally suppressed because, with `ticks.mirror`, the
+ * topmost/bottommost label can clip against the pane edge. But oscillator panes
+ * are short (the docs use `aspect-ratio: 6`), so Chart.js often fits only two or
+ * three gridlines. Dropping both ends there leaves zero or one visible label —
+ * the "right axis isn't shown" symptom. Keep every label until the pane has
+ * enough ticks to spare the bounds. See issue #495.
+ */
+const MIN_TICKS_TO_TRIM_BOUNDS = 4;
+
 export function baseOscillatorConfig(settings: ChartSettings): ChartConfiguration {
   const config: ChartConfiguration = {
     type: "line",
@@ -32,8 +45,11 @@ export function baseOscillatorOptions(settings: ChartSettings): ChartOptions {
     const numValue = typeof value === "string" ? parseFloat(value) : value;
     const v = Math.abs(numValue);
 
-    // remove first and last y-axis labels
-    if (index === 0 || index === values.length - 1) return null;
+    // Drop the first and last y-axis labels only when the pane has enough
+    // gridlines to spare them; on short panes keep the bounds visible so the
+    // axis range is still readable (issue #495).
+    if (values.length >= MIN_TICKS_TO_TRIM_BOUNDS && (index === 0 || index === values.length - 1))
+      return null;
     // otherwise, condense large/small display values
     else if (v > 10000000000) return Math.trunc(numValue / 1000000000) + "B";
     else if (v > 10000000) return Math.trunc(numValue / 1000000) + "M";

--- a/libs/indy-charts/data/transformers.ts
+++ b/libs/indy-charts/data/transformers.ts
@@ -59,11 +59,7 @@ export function buildDataPoints(
 
     // apply candle pointers (CANDLESTICK_PATTERN rows include a `candle` field
     // from the API; skip the styling if a fixture-supplied row omits it)
-    if (
-      yValue !== undefined &&
-      listing.category === CATEGORIES.CANDLESTICK_PATTERN &&
-      row.candle
-    ) {
+    if (yValue !== undefined && listing.category === CATEGORIES.CANDLESTICK_PATTERN && row.candle) {
       const rawMatch = row["match"];
       const matchValue = typeof rawMatch === "number" ? rawMatch : 0;
       const candleConfig = getCandlePointConfiguration(matchValue, row.candle);
@@ -80,9 +76,7 @@ export function buildDataPoints(
       yValue = NaN;
     }
     if (row.timestamp == null) {
-      throw new Error(
-        `Indicator row missing 'timestamp' field for "${result.dataName}"`
-      );
+      throw new Error(`Indicator row missing 'timestamp' field for "${result.dataName}"`);
     }
     const x = new Date(row.timestamp).valueOf();
     if (!Number.isFinite(x)) {

--- a/libs/indy-charts/package.json
+++ b/libs/indy-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@facioquo/indy-charts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Framework-agnostic financial charting library with technical indicators and stock market data visualization",
   "author": "facioquo",
   "license": "Apache-2.0",

--- a/libs/indy-charts/vue/index.ts
+++ b/libs/indy-charts/vue/index.ts
@@ -5,11 +5,7 @@ import { StockIndicatorChart } from "./stock-indicator-chart";
 import type { IndyChartsVueOptions } from "./types";
 
 export { StockIndicatorChart } from "./stock-indicator-chart";
-export {
-  getTestIdPrefix,
-  slug,
-  STOCK_INDICATOR_CHART_TESTID_PREFIX
-} from "./slug";
+export { getTestIdPrefix, slug, STOCK_INDICATOR_CHART_TESTID_PREFIX } from "./slug";
 export type {
   IndyChartsVueApiOptions,
   IndyChartsVueDefaults,

--- a/libs/indy-charts/vue/stock-indicator-chart.spec.ts
+++ b/libs/indy-charts/vue/stock-indicator-chart.spec.ts
@@ -7,6 +7,38 @@ import { StockIndicatorChart } from "./stock-indicator-chart";
 import { chartSettingsFromOptions } from "./types";
 import type { IndyChartsVueOptions } from "./types";
 
+// ChartManager and setupIndyCharts create real Chart.js instances bound to a
+// canvas, which the node test renderer can't provide. Mock them so the
+// composition logic (panel routing, manager wiring) is exercised in isolation.
+// No other test in this file constructs a ChartManager or calls setupIndyCharts.
+const managerSpies = vi.hoisted(() => ({ instances: [] as MockChartManager[] }));
+
+interface MockChartManager {
+  initializeOverlay: ReturnType<typeof vi.fn>;
+  processSelectionData: ReturnType<typeof vi.fn>;
+  displaySelection: ReturnType<typeof vi.fn>;
+  createOscillator: ReturnType<typeof vi.fn>;
+  updateTheme: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+vi.mock("../setup", () => ({ setupIndyCharts: vi.fn() }));
+
+vi.mock("../charts", () => {
+  class ChartManager {
+    initializeOverlay = vi.fn();
+    processSelectionData = vi.fn();
+    displaySelection = vi.fn();
+    createOscillator = vi.fn();
+    updateTheme = vi.fn();
+    destroy = vi.fn();
+    constructor() {
+      managerSpies.instances.push(this);
+    }
+  }
+  return { ChartManager };
+});
+
 type TestNode = TestElement | TestText;
 
 interface TestElement {
@@ -174,7 +206,7 @@ describe("StockIndicatorChart", () => {
     app.unmount();
   });
 
-  it("tags author-facing errors with data-error-kind=\"author\"", async () => {
+  it('tags author-facing errors with data-error-kind="author"', async () => {
     const root = createTestElement("root");
     const app = renderer.createApp(StockIndicatorChart, { indicator: "rsi" });
     // Intentionally omit provide() — triggers MISSING_SETUP_ERROR_MESSAGE, which is author-facing.
@@ -234,7 +266,7 @@ describe("StockIndicatorChart", () => {
     app.unmount();
   });
 
-  it("falls back to id=\"chart\" when id/config.id/indicator slugify to empty", async () => {
+  it('falls back to id="chart" when id/config.id/indicator slugify to empty', async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(() => new Promise<Response>(() => undefined))
@@ -360,6 +392,164 @@ describe("chartSettingsFromOptions", () => {
     };
     const result = chartSettingsFromOptions(options, true, "");
     expect(result.background).toBe("#dark-theme");
+  });
+});
+
+function makeBollingerListings(): unknown[] {
+  const lookback = {
+    paramName: "lookbackPeriods",
+    displayName: "Periods",
+    minimum: 1,
+    maximum: 250,
+    defaultValue: 20
+  };
+  const stdDev = {
+    paramName: "standardDeviations",
+    displayName: "Std Dev",
+    minimum: 1,
+    maximum: 5,
+    defaultValue: 2
+  };
+  return [
+    {
+      uiid: "BB",
+      name: "Bollinger Bands",
+      legendTemplate: "BB([P1],[P2])",
+      endpoint: "BB/",
+      category: "price-channel",
+      chartType: "overlay",
+      order: 1,
+      chartConfig: null,
+      parameters: [lookback, stdDev],
+      results: [
+        {
+          dataName: "upperBand",
+          displayName: "Upper Band",
+          tooltipTemplate: "Upper",
+          defaultColor: "#AAAAAA",
+          lineType: "solid",
+          lineWidth: 1,
+          dataType: "number",
+          stack: "",
+          order: 1
+        }
+      ]
+    },
+    {
+      uiid: "BB-PCTB",
+      name: "Bollinger Bands %B",
+      legendTemplate: "BB([P1],[P2]) %B",
+      endpoint: "BB/",
+      category: "oscillator",
+      chartType: "oscillator",
+      order: 2,
+      chartConfig: { minimumYAxis: 0, maximumYAxis: 1, thresholds: [] },
+      parameters: [lookback, stdDev],
+      results: [
+        {
+          dataName: "percentB",
+          displayName: "%B",
+          tooltipTemplate: "%B",
+          defaultColor: "#8E24AA",
+          lineType: "solid",
+          lineWidth: 2,
+          dataType: "number",
+          stack: "",
+          order: 1
+        }
+      ]
+    }
+  ];
+}
+
+function bollingerFetch() {
+  const quotes = Array.from({ length: 10 }, (_, i) => ({
+    timestamp: new Date(2024, 0, i + 1).toISOString(),
+    open: 100 + i,
+    high: 105 + i,
+    low: 95 + i,
+    close: 101 + i,
+    volume: 1000 + i
+  }));
+  const rows = quotes.map(q => ({
+    timestamp: q.timestamp,
+    candle: q,
+    upperBand: 110,
+    percentB: 0.5
+  }));
+
+  return vi.fn((input: RequestInfo | URL): Promise<Response> => {
+    const url = requestUrl(input);
+    if (url.endsWith("/quotes")) return Promise.resolve(responseJson(quotes));
+    if (url.endsWith("/indicators")) return Promise.resolve(responseJson(makeBollingerListings()));
+    if (url.includes("/BB/")) return Promise.resolve(responseJson(rows));
+    return Promise.reject(new Error(`Unexpected fetch URL: ${url}`));
+  });
+}
+
+const bollingerOptions: IndyChartsVueOptions = {
+  api: { baseUrl: "https://localhost:5001" },
+  indicators: {
+    bb: { uiid: "BB" },
+    bbPctB: { uiid: "BB-PCTB" }
+  }
+};
+
+describe("StockIndicatorChart composition (with prop)", () => {
+  it("composes an overlay indicator and a companion oscillator under one manager", async () => {
+    managerSpies.instances.length = 0;
+    vi.stubGlobal("fetch", bollingerFetch());
+
+    const root = createTestElement("root");
+    const app = renderer.createApp(StockIndicatorChart, {
+      indicator: "bb",
+      with: "bbPctB",
+      id: "bb-combo"
+    });
+    app.provide(indyChartsVueOptionsKey, bollingerOptions);
+    app.mount(root);
+
+    await vi.waitFor(() => {
+      expect(findByTestId(root, "stock-indicator-chart-bb-combo-overlay-canvas")).toBeDefined();
+      expect(findByTestId(root, "stock-indicator-chart-bb-combo-oscillator-canvas")).toBeDefined();
+    });
+
+    // No error state — the chart reached the ready phase.
+    expect(findByTestId(root, "stock-indicator-chart-bb-combo-error")).toBeUndefined();
+
+    // Exactly one ChartManager backs both panels.
+    expect(managerSpies.instances).toHaveLength(1);
+    const mgr = managerSpies.instances[0];
+    expect(mgr.initializeOverlay).toHaveBeenCalledTimes(1);
+    // Both indicators registered; only the oscillator gets a createOscillator call.
+    expect(mgr.displaySelection).toHaveBeenCalledTimes(2);
+    expect(mgr.createOscillator).toHaveBeenCalledTimes(1);
+
+    app.unmount();
+  });
+
+  it("renders a standalone oscillator without an overlay canvas", async () => {
+    managerSpies.instances.length = 0;
+    vi.stubGlobal("fetch", bollingerFetch());
+
+    const root = createTestElement("root");
+    const app = renderer.createApp(StockIndicatorChart, {
+      indicator: "bbPctB",
+      id: "pctb-only"
+    });
+    app.provide(indyChartsVueOptionsKey, bollingerOptions);
+    app.mount(root);
+
+    await vi.waitFor(() => {
+      expect(findByTestId(root, "stock-indicator-chart-pctb-only-oscillator-canvas")).toBeDefined();
+    });
+
+    expect(findByTestId(root, "stock-indicator-chart-pctb-only-overlay-canvas")).toBeUndefined();
+    const mgr = managerSpies.instances[0];
+    expect(mgr.initializeOverlay).not.toHaveBeenCalled();
+    expect(mgr.createOscillator).toHaveBeenCalledTimes(1);
+
+    app.unmount();
   });
 });
 

--- a/libs/indy-charts/vue/stock-indicator-chart.spec.ts
+++ b/libs/indy-charts/vue/stock-indicator-chart.spec.ts
@@ -545,8 +545,35 @@ describe("StockIndicatorChart composition (with prop)", () => {
     });
 
     expect(findByTestId(root, "stock-indicator-chart-pctb-only-overlay-canvas")).toBeUndefined();
+    expect(managerSpies.instances).toHaveLength(1);
     const mgr = managerSpies.instances[0];
     expect(mgr.initializeOverlay).not.toHaveBeenCalled();
+    expect(mgr.createOscillator).toHaveBeenCalledTimes(1);
+
+    app.unmount();
+  });
+
+  it("de-duplicates a companion that repeats the primary indicator", async () => {
+    managerSpies.instances.length = 0;
+    vi.stubGlobal("fetch", bollingerFetch());
+
+    const root = createTestElement("root");
+    const app = renderer.createApp(StockIndicatorChart, {
+      indicator: "bb",
+      with: ["bb", "bbPctB", "bbPctB"],
+      id: "bb-dedup"
+    });
+    app.provide(indyChartsVueOptionsKey, bollingerOptions);
+    app.mount(root);
+
+    await vi.waitFor(() => {
+      expect(findByTestId(root, "stock-indicator-chart-bb-dedup-oscillator-canvas")).toBeDefined();
+    });
+
+    expect(managerSpies.instances).toHaveLength(1);
+    const mgr = managerSpies.instances[0];
+    // BB (overlay) + %B (oscillator) only — duplicates collapse away.
+    expect(mgr.displaySelection).toHaveBeenCalledTimes(2);
     expect(mgr.createOscillator).toHaveBeenCalledTimes(1);
 
     app.unmount();

--- a/libs/indy-charts/vue/stock-indicator-chart.ts
+++ b/libs/indy-charts/vue/stock-indicator-chart.ts
@@ -65,11 +65,16 @@ function registryConfig(
   return indicator ? registry[indicator] : undefined;
 }
 
-/** Normalize the `with` prop/config value to a list of non-empty indicator names. */
+/**
+ * Normalize the `with` prop/config value to a de-duplicated list of non-empty
+ * indicator names. Duplicates are dropped so the same companion is not fetched
+ * and rendered twice.
+ */
 function normalizeWithList(value: string | string[] | undefined): string[] {
   if (value == null) return [];
   const list = Array.isArray(value) ? value : [value];
-  return list.map(name => name.trim()).filter(name => name.length > 0);
+  const trimmed = list.map(name => name.trim()).filter(name => name.length > 0);
+  return [...new Set(trimmed)];
 }
 
 function isAuthorFacingError(error: unknown): error is Error {
@@ -214,13 +219,18 @@ export const StockIndicatorChart = defineComponent({
         { config: primary, name: props.indicator ?? options.defaults?.indicator ?? "chart" }
       ];
 
+      // Track resolved uiids (case-insensitive) so a companion that duplicates
+      // the primary — or another companion — is not fetched and rendered twice.
+      const seenUiids = new Set<string>();
+      if (primary.uiid) seenUiids.add(primary.uiid.toLowerCase());
+
       const companions = normalizeWithList(props.with ?? props.config.with);
       for (const name of companions) {
         const registered = registryConfig(options, name) ?? {};
-        indicators.push({
-          config: { ...registered, uiid: registered.uiid ?? name },
-          name
-        });
+        const uiid = registered.uiid ?? name;
+        if (seenUiids.has(uiid.toLowerCase())) continue;
+        seenUiids.add(uiid.toLowerCase());
+        indicators.push({ config: { ...registered, uiid }, name });
       }
 
       return indicators;
@@ -286,40 +296,46 @@ export const StockIndicatorChart = defineComponent({
           return;
         }
 
-        const prepared: PreparedIndicator[] = [];
-        for (const indicator of indicators) {
-          const uiid = indicator.config.uiid;
-          if (!uiid) {
-            throw new Error("A chart indicator or config.uiid is required.");
-          }
+        // Load every indicator's selection data concurrently. Promise.all
+        // preserves order, so the primary stays first and oscillator panes keep
+        // a deterministic order. A rejected fetch (e.g. an unknown listing)
+        // surfaces through the outer try/catch as the error state.
+        const results = await Promise.all(
+          indicators.map(async (indicator): Promise<PreparedIndicator | null> => {
+            const uiid = indicator.config.uiid;
+            if (!uiid) {
+              throw new Error("A chart indicator or config.uiid is required.");
+            }
 
-          const listing = findListing(listings, uiid);
-          if (!listing) {
-            throw new Error(`Indicator listing not found for uiid "${uiid}".`);
-          }
+            const listing = findListing(listings, uiid);
+            if (!listing) {
+              throw new Error(`Indicator listing not found for uiid "${uiid}".`);
+            }
 
-          const selection = buildSelection(indicator.config, listing);
-          const rows = loadStaticIndicatorData(await client.getSelectionData(selection, listing));
-          if (disposed || token !== loadToken) return;
+            const selection = buildSelection(indicator.config, listing);
+            const rows = loadStaticIndicatorData(await client.getSelectionData(selection, listing));
 
-          const chartRows = rows.slice(-chartQuotes.length);
-          if (chartRows.length === 0) {
-            // A companion with no data is skipped so the rest of the chart still
-            // renders; an empty primary collapses the chart to the empty state.
-            console.warn(
-              `[indy-charts] No data returned for indicator "${indicator.name}" (uiid "${uiid}").`
-            );
-            continue;
-          }
+            const chartRows = rows.slice(-chartQuotes.length);
+            if (chartRows.length === 0) {
+              // A companion with no data is skipped so the rest of the chart
+              // still renders; an empty primary collapses to the empty state.
+              console.warn(
+                `[indy-charts] No data returned for indicator "${indicator.name}" (uiid "${uiid}").`
+              );
+              return null;
+            }
 
-          prepared.push({
-            selection,
-            listing,
-            chartRows,
-            isOscillator: listing.chartType === OSCILLATOR_CHART_TYPE
-          });
-        }
+            return {
+              selection,
+              listing,
+              chartRows,
+              isOscillator: listing.chartType === OSCILLATOR_CHART_TYPE
+            };
+          })
+        );
+        if (disposed || token !== loadToken) return;
 
+        const prepared = results.filter((item): item is PreparedIndicator => item !== null);
         if (prepared.length === 0) {
           phase.value = "empty";
           return;

--- a/libs/indy-charts/vue/stock-indicator-chart.ts
+++ b/libs/indy-charts/vue/stock-indicator-chart.ts
@@ -13,7 +13,7 @@ import {
 
 import { createApiClient, loadStaticIndicatorData } from "../api";
 import { ChartManager } from "../charts";
-import type { IndicatorListing } from "../config";
+import type { IndicatorDataRow, IndicatorListing, IndicatorSelection } from "../config";
 import { applySelectionTokens, createDefaultSelection } from "../helpers";
 import { setupIndyCharts } from "../setup";
 import { indyChartsVueOptionsKey } from "./context";
@@ -26,9 +26,32 @@ import {
 } from "./types";
 
 const DEFAULT_BAR_COUNT = 250;
+const OSCILLATOR_CHART_TYPE = "oscillator";
 const DATA_UNAVAILABLE_ERROR_MESSAGE =
   "Chart data is currently unavailable. Check the API service and try again.";
 const MISSING_SETUP_ERROR_MESSAGE = "setupIndyChartsForVue() has not been called.";
+
+/** A single indicator resolved to a chart config, ready for data loading. */
+interface ResolvedIndicator {
+  config: StockIndicatorChartConfig;
+  /** Original lookup name (registry key or uiid) used for diagnostics. */
+  name: string;
+}
+
+/** An indicator whose selection and data are ready to hand to the ChartManager. */
+interface PreparedIndicator {
+  selection: IndicatorSelection;
+  listing: IndicatorListing;
+  chartRows: IndicatorDataRow[];
+  isOscillator: boolean;
+}
+
+/** Describes one oscillator canvas pane to render in the template. */
+interface OscillatorPane {
+  /** Stable key (the selection ucid) used for the canvas ref map and v-for key. */
+  key: string;
+  testId: string;
+}
 
 function findListing(listings: IndicatorListing[], uiid: string): IndicatorListing | undefined {
   return listings.find(listing => listing.uiid.toLowerCase() === uiid.toLowerCase());
@@ -40,6 +63,13 @@ function registryConfig(
 ): StockIndicatorChartConfig | undefined {
   const registry = options.indicators ?? {};
   return indicator ? registry[indicator] : undefined;
+}
+
+/** Normalize the `with` prop/config value to a list of non-empty indicator names. */
+function normalizeWithList(value: string | string[] | undefined): string[] {
+  if (value == null) return [];
+  const list = Array.isArray(value) ? value : [value];
+  return list.map(name => name.trim()).filter(name => name.length > 0);
 }
 
 function isAuthorFacingError(error: unknown): error is Error {
@@ -84,6 +114,15 @@ export const StockIndicatorChart = defineComponent({
       type: Boolean,
       required: false
     },
+    /**
+     * Companion indicator name(s) to compose into the same chart under one
+     * ChartManager. Overlay-type companions render on the shared price panel;
+     * oscillator-type companions render as aligned panes beneath it.
+     */
+    with: {
+      type: [String, Array] as PropType<string | string[]>,
+      required: false
+    },
     background: {
       type: String,
       required: false
@@ -94,22 +133,31 @@ export const StockIndicatorChart = defineComponent({
     const phase = ref<StockIndicatorChartPhase>("idle");
     const errorMessage = ref(DATA_UNAVAILABLE_ERROR_MESSAGE);
     const errorKind = ref<"author" | "data">("data");
-    const chartType = ref<string>("overlay");
+    const overlayVisible = ref(false);
+    const oscillatorPanes = ref<OscillatorPane[]>([]);
     const overlayCanvas = ref<HTMLCanvasElement | null>(null);
-    const oscillatorCanvas = ref<HTMLCanvasElement | null>(null);
+    const oscillatorCanvases = new Map<string, HTMLCanvasElement>();
     const rootId = computed(() => {
       const normalized = slug(props.id ?? props.config.id ?? props.indicator ?? "chart");
       return normalized || "chart";
     });
     const testIdPrefix = computed(() => `${STOCK_INDICATOR_CHART_TESTID_PREFIX}-${rootId.value}`);
-    const showOverlayCanvas = computed(
-      () => chartType.value !== "oscillator" || props.withOverlay === true
-    );
 
     let manager: ChartManager | undefined;
     let loadToken = 0;
     let disposed = false;
     let themeObserver: MutationObserver | undefined;
+
+    function setOscillatorCanvas(key: string, el: unknown): void {
+      // Vue invokes the ref callback with the element on mount and `null` on
+      // unmount; mirror the overlay ref's truthiness handling (store on mount,
+      // drop on unmount) so each oscillator pane's canvas stays addressable.
+      if (el) {
+        oscillatorCanvases.set(key, el as HTMLCanvasElement);
+      } else {
+        oscillatorCanvases.delete(key);
+      }
+    }
 
     function destroyChart(): void {
       manager?.destroy();
@@ -151,9 +199,64 @@ export const StockIndicatorChart = defineComponent({
       };
     }
 
+    /**
+     * Resolve the primary indicator plus any `with` companions to chart configs.
+     * The primary merges registry defaults with the `config` prop; companions
+     * resolve from the registry (falling back to the name as a uiid).
+     */
+    function resolvedIndicators(): ResolvedIndicator[] {
+      if (!options) {
+        throw new Error(MISSING_SETUP_ERROR_MESSAGE);
+      }
+
+      const primary = resolvedConfig();
+      const indicators: ResolvedIndicator[] = [
+        { config: primary, name: props.indicator ?? options.defaults?.indicator ?? "chart" }
+      ];
+
+      const companions = normalizeWithList(props.with ?? props.config.with);
+      for (const name of companions) {
+        const registered = registryConfig(options, name) ?? {};
+        indicators.push({
+          config: { ...registered, uiid: registered.uiid ?? name },
+          name
+        });
+      }
+
+      return indicators;
+    }
+
+    /**
+     * Build a selection for one indicator, applying any requested results
+     * filter and replacing label tokens. Returns the populated selection.
+     */
+    function buildSelection(
+      config: StockIndicatorChartConfig,
+      listing: IndicatorListing
+    ): IndicatorSelection {
+      const selection = createDefaultSelection(listing, config.params, `${rootId.value}-`);
+      if (config.results?.length) {
+        const wanted = new Set(config.results.map(result => result.toLowerCase()));
+        const filtered = selection.results.filter(result =>
+          wanted.has(result.dataName.toLowerCase())
+        );
+        if (filtered.length === 0) {
+          console.warn(
+            `[indy-charts] None of the requested results [${config.results.join(", ")}] ` +
+              `match available result names for uiid "${config.uiid}". ` +
+              `Available: [${selection.results.map(r => r.dataName).join(", ")}].`
+          );
+        }
+        selection.results = filtered;
+      }
+      applySelectionTokens(selection);
+      return selection;
+    }
+
     async function loadChart(): Promise<void> {
       const token = ++loadToken;
       destroyChart();
+      oscillatorCanvases.clear();
       phase.value = "loading";
       errorMessage.value = DATA_UNAVAILABLE_ERROR_MESSAGE;
       errorKind.value = "data";
@@ -163,8 +266,9 @@ export const StockIndicatorChart = defineComponent({
           throw new Error(MISSING_SETUP_ERROR_MESSAGE);
         }
 
-        const config = resolvedConfig();
-        if (!config.uiid) {
+        const indicators = resolvedIndicators();
+        const primaryConfig = indicators[0].config;
+        if (!primaryConfig.uiid) {
           throw new Error("A chart indicator or config.uiid is required.");
         }
 
@@ -172,13 +276,8 @@ export const StockIndicatorChart = defineComponent({
         const [quotes, listings] = await Promise.all([client.getQuotes(), client.getListings()]);
         if (disposed || token !== loadToken) return;
 
-        const listing = findListing(listings, config.uiid);
-        if (!listing) {
-          throw new Error(`Indicator listing not found for uiid "${config.uiid}".`);
-        }
-
         const quoteCount = normalizeWindowSize(
-          config.quoteCount ?? options.defaults?.quoteCount ?? DEFAULT_BAR_COUNT,
+          primaryConfig.quoteCount ?? options.defaults?.quoteCount ?? DEFAULT_BAR_COUNT,
           quotes.length
         );
         const chartQuotes = quotes.slice(-quoteCount);
@@ -187,43 +286,68 @@ export const StockIndicatorChart = defineComponent({
           return;
         }
 
-        const selection = createDefaultSelection(listing, config.params, `${rootId.value}-`);
-        if (config.results?.length) {
-          const wanted = new Set(config.results.map(result => result.toLowerCase()));
-          const filtered = selection.results.filter(result =>
-            wanted.has(result.dataName.toLowerCase())
-          );
-          if (filtered.length === 0) {
-            console.warn(
-              `[indy-charts] None of the requested results [${config.results.join(", ")}] ` +
-                `match available result names for uiid "${config.uiid}". ` +
-                `Available: [${selection.results.map(r => r.dataName).join(", ")}].`
-            );
+        const prepared: PreparedIndicator[] = [];
+        for (const indicator of indicators) {
+          const uiid = indicator.config.uiid;
+          if (!uiid) {
+            throw new Error("A chart indicator or config.uiid is required.");
           }
-          selection.results = filtered;
+
+          const listing = findListing(listings, uiid);
+          if (!listing) {
+            throw new Error(`Indicator listing not found for uiid "${uiid}".`);
+          }
+
+          const selection = buildSelection(indicator.config, listing);
+          const rows = loadStaticIndicatorData(await client.getSelectionData(selection, listing));
+          if (disposed || token !== loadToken) return;
+
+          const chartRows = rows.slice(-chartQuotes.length);
+          if (chartRows.length === 0) {
+            // A companion with no data is skipped so the rest of the chart still
+            // renders; an empty primary collapses the chart to the empty state.
+            console.warn(
+              `[indy-charts] No data returned for indicator "${indicator.name}" (uiid "${uiid}").`
+            );
+            continue;
+          }
+
+          prepared.push({
+            selection,
+            listing,
+            chartRows,
+            isOscillator: listing.chartType === OSCILLATOR_CHART_TYPE
+          });
         }
-        applySelectionTokens(selection);
 
-        const rows = loadStaticIndicatorData(await client.getSelectionData(selection, listing));
-        const chartRows = rows.slice(-chartQuotes.length);
-        if (disposed || token !== loadToken) return;
-
-        if (chartRows.length === 0) {
+        if (prepared.length === 0) {
           phase.value = "empty";
           return;
         }
 
-        chartType.value = listing.chartType;
+        const overlays = prepared.filter(item => !item.isOscillator);
+        const oscillators = prepared.filter(item => item.isOscillator);
+        const needsOverlay = overlays.length > 0 || props.withOverlay === true;
+
+        overlayVisible.value = needsOverlay;
+        oscillatorPanes.value = oscillators.map((item, index) => ({
+          key: item.selection.ucid,
+          testId:
+            index === 0
+              ? `${testIdPrefix.value}-oscillator-canvas`
+              : `${testIdPrefix.value}-oscillator-canvas-${index}`
+        }));
+
         phase.value = "ready";
         await nextTick();
-
         if (disposed || token !== loadToken) return;
-        const isOscillator = listing.chartType === "oscillator";
-        const needsOverlay = !isOscillator || props.withOverlay === true;
 
         setupIndyCharts();
         const barCount =
-          props.barCount ?? config.barCount ?? options.defaults?.barCount ?? DEFAULT_BAR_COUNT;
+          props.barCount ??
+          primaryConfig.barCount ??
+          options.defaults?.barCount ??
+          DEFAULT_BAR_COUNT;
         const normalizedBarCount = normalizeWindowSize(barCount, chartQuotes.length);
         const chartManager = new ChartManager({ settings: currentSettings() });
         manager = chartManager;
@@ -235,14 +359,23 @@ export const StockIndicatorChart = defineComponent({
           chartManager.initializeOverlay(overlayCanvas.value, chartQuotes, normalizedBarCount);
         }
 
-        chartManager.processSelectionData(selection, listing, chartRows);
-        chartManager.displaySelection(selection, listing);
+        // Overlay-type indicators attach to the shared price panel first so the
+        // windowed x-axis is established before oscillators align to it.
+        for (const item of overlays) {
+          chartManager.processSelectionData(item.selection, item.listing, item.chartRows);
+          chartManager.displaySelection(item.selection, item.listing);
+        }
 
-        if (isOscillator) {
-          if (!oscillatorCanvas.value) {
+        // Each oscillator renders into its own canvas, re-sliced to the same
+        // windowed range as the overlay so the panes stay x-axis aligned.
+        for (const item of oscillators) {
+          const canvas = oscillatorCanvases.get(item.selection.ucid);
+          if (!canvas) {
             throw new Error("Oscillator chart canvas is not available.");
           }
-          chartManager.createOscillator(oscillatorCanvas.value, selection, listing);
+          chartManager.processSelectionData(item.selection, item.listing, item.chartRows);
+          chartManager.displaySelection(item.selection, item.listing);
+          chartManager.createOscillator(canvas, item.selection, item.listing);
         }
       } catch (error) {
         if (disposed || token !== loadToken) return;
@@ -286,7 +419,9 @@ export const StockIndicatorChart = defineComponent({
           props.indicator,
           props.barCount,
           props.withOverlay,
+          props.with,
           props.config.uiid,
+          props.config.with,
           props.config.barCount,
           props.config.quoteCount,
           props.config.params,
@@ -377,7 +512,7 @@ export const StockIndicatorChart = defineComponent({
             : null,
           phase.value === "ready"
             ? h("div", { class: "indy-demo__stack" }, [
-                showOverlayCanvas.value
+                overlayVisible.value
                   ? h("div", { class: "indy-demo__canvas-wrap indy-demo__canvas-wrap--overlay" }, [
                       h("canvas", {
                         ref: overlayCanvas,
@@ -386,19 +521,22 @@ export const StockIndicatorChart = defineComponent({
                       })
                     ])
                   : null,
-                chartType.value === "oscillator"
-                  ? h(
-                      "div",
-                      { class: "indy-demo__canvas-wrap indy-demo__canvas-wrap--oscillator" },
-                      [
-                        h("canvas", {
-                          ref: oscillatorCanvas,
-                          class: "indy-demo__canvas",
-                          "data-testid": `${testIdPrefix.value}-oscillator-canvas`
-                        })
-                      ]
-                    )
-                  : null
+                ...oscillatorPanes.value.map(pane =>
+                  h(
+                    "div",
+                    {
+                      key: pane.key,
+                      class: "indy-demo__canvas-wrap indy-demo__canvas-wrap--oscillator"
+                    },
+                    [
+                      h("canvas", {
+                        ref: (el: unknown) => setOscillatorCanvas(pane.key, el),
+                        class: "indy-demo__canvas",
+                        "data-testid": pane.testId
+                      })
+                    ]
+                  )
+                )
               ])
             : null
         ]

--- a/libs/indy-charts/vue/types.ts
+++ b/libs/indy-charts/vue/types.ts
@@ -11,6 +11,12 @@ export interface StockIndicatorChartConfig {
   results?: string[];
   barCount?: number;
   quoteCount?: number;
+  /**
+   * Companion indicator name(s) to compose into the same chart. Overlay-type
+   * companions render on the shared price panel; oscillator-type companions
+   * render as aligned panes beneath it. The `with` prop takes precedence.
+   */
+  with?: string | string[];
   /** Per-instance background color for annotation and axis-label backdrops. */
   background?: string;
 }
@@ -59,6 +65,17 @@ export interface StockIndicatorChartProps {
   config?: StockIndicatorChartConfig;
   barCount?: number;
   withOverlay?: boolean;
+  /**
+   * Companion indicator name(s) to compose into the same chart under one
+   * `ChartManager`, sharing the price panel's windowed x-axis. Overlay-type
+   * companions render on the price panel; oscillator-type companions render as
+   * vertically aligned panes beneath it. Accepts a single name or an array.
+   *
+   * Example: `<StockIndicatorChart indicator="bb" with="bbPctB" />` renders the
+   * Bollinger Bands overlay on the price panel and the %B oscillator aligned
+   * below it. Takes precedence over `config.with`.
+   */
+  with?: string | string[];
   /** Per-instance background color for annotation and axis-label backdrops. */
   background?: string;
 }

--- a/tests/playwright/vitepress.spec.ts
+++ b/tests/playwright/vitepress.spec.ts
@@ -102,6 +102,117 @@ const mockListings = [
         order: 1
       }
     ]
+  },
+  {
+    name: "Bollinger Bands®",
+    uiid: "BB",
+    legendTemplate: "BB([P1],[P2])",
+    endpoint: "BB/",
+    category: "price-channel",
+    chartType: "overlay",
+    order: 3,
+    chartConfig: null,
+    parameters: [
+      {
+        displayName: "Lookback periods",
+        paramName: "lookbackPeriods",
+        dataType: "int",
+        defaultValue: 20,
+        minimum: 2,
+        maximum: 250
+      },
+      {
+        displayName: "Standard deviations",
+        paramName: "standardDeviations",
+        dataType: "number",
+        defaultValue: 2,
+        minimum: 0.01,
+        maximum: 10
+      }
+    ],
+    results: [
+      {
+        displayName: "Upper Band",
+        tooltipTemplate: "Upper",
+        dataName: "upperBand",
+        dataType: "number",
+        lineType: "solid",
+        stack: "",
+        lineWidth: 1,
+        defaultColor: "#9ca3af",
+        order: 1
+      },
+      {
+        displayName: "Centerline",
+        tooltipTemplate: "Center",
+        dataName: "sma",
+        dataType: "number",
+        lineType: "dash",
+        stack: "",
+        lineWidth: 1,
+        defaultColor: "#9ca3af",
+        order: 2
+      },
+      {
+        displayName: "Lower Band",
+        tooltipTemplate: "Lower",
+        dataName: "lowerBand",
+        dataType: "number",
+        lineType: "solid",
+        stack: "",
+        lineWidth: 1,
+        defaultColor: "#9ca3af",
+        order: 3
+      }
+    ]
+  },
+  {
+    name: "Bollinger Bands® %B",
+    uiid: "BB-PCTB",
+    legendTemplate: "BB([P1],[P2]) %B",
+    endpoint: "BB/",
+    category: "oscillator",
+    chartType: "oscillator",
+    order: 4,
+    chartConfig: {
+      minimumYAxis: 0,
+      maximumYAxis: 1,
+      thresholds: [
+        { value: 1, color: "#dc2626", style: "dash", fill: null },
+        { value: 0, color: "#16a34a", style: "dash", fill: null }
+      ]
+    },
+    parameters: [
+      {
+        displayName: "Lookback periods",
+        paramName: "lookbackPeriods",
+        dataType: "int",
+        defaultValue: 20,
+        minimum: 2,
+        maximum: 250
+      },
+      {
+        displayName: "Standard deviations",
+        paramName: "standardDeviations",
+        dataType: "number",
+        defaultValue: 2,
+        minimum: 0.01,
+        maximum: 10
+      }
+    ],
+    results: [
+      {
+        displayName: "%B",
+        tooltipTemplate: "%B: $VALUE",
+        dataName: "percentB",
+        dataType: "number",
+        lineType: "solid",
+        stack: "",
+        lineWidth: 2,
+        defaultColor: "#2563eb",
+        order: 1
+      }
+    ]
   }
 ];
 
@@ -116,6 +227,14 @@ async function mockChartApi(page: Page): Promise<void> {
     timestamp: quote.timestamp,
     candle: quote,
     rsi: 45 + Math.sin(index / 5) * 20
+  }));
+  const bbData = mockQuotes.map((quote, index) => ({
+    timestamp: quote.timestamp,
+    candle: quote,
+    upperBand: quote.close + 4,
+    sma: quote.close,
+    lowerBand: quote.close - 4,
+    percentB: 0.5 + Math.sin(index / 5) * 0.4
   }));
 
   // Intercept both the local dev server and the production API origin so the
@@ -132,6 +251,9 @@ async function mockChartApi(page: Page): Promise<void> {
     );
     await page.route(`${base}/rsi**`, route =>
       route.fulfill({ json: rsiData, headers: { "access-control-allow-origin": "*" } })
+    );
+    await page.route(`${base}/BB/**`, route =>
+      route.fulfill({ json: bbData, headers: { "access-control-allow-origin": "*" } })
     );
   }
 }
@@ -277,5 +399,32 @@ test.describe("VitePress Documentation Site", () => {
     await expectCanvasToBeNonBlank(
       page.getByTestId("stock-indicator-chart-rsi-with-overlay-oscillator-canvas")
     );
+  });
+
+  test("composed chart aligns an overlay indicator with its companion oscillator", async ({
+    page
+  }) => {
+    await mockChartApi(page);
+    await page.goto("/examples/indicators");
+
+    const root = page.getByTestId("stock-indicator-chart-bb-combo-root");
+    await expect(root).toBeVisible();
+    await expect(page.getByTestId("stock-indicator-chart-bb-combo-error")).toHaveCount(0);
+
+    // One component renders both the Bollinger Bands overlay (price panel) and
+    // the %B oscillator pane beneath it.
+    const overlay = page.getByTestId("stock-indicator-chart-bb-combo-overlay-canvas");
+    const oscillator = page.getByTestId("stock-indicator-chart-bb-combo-oscillator-canvas");
+    await expectCanvasToBeNonBlank(overlay);
+    await expectCanvasToBeNonBlank(oscillator);
+
+    // The panels share one ChartManager, so their plot areas align horizontally:
+    // both canvases must have the same left edge and width (issue #494/#496).
+    const overlayBox = await overlay.boundingBox();
+    const oscillatorBox = await oscillator.boundingBox();
+    expect(overlayBox).not.toBeNull();
+    expect(oscillatorBox).not.toBeNull();
+    expect(Math.abs(overlayBox!.x - oscillatorBox!.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(overlayBox!.width - oscillatorBox!.width)).toBeLessThanOrEqual(1);
   });
 });

--- a/tests/vitepress/.vitepress/theme/index.ts
+++ b/tests/vitepress/.vitepress/theme/index.ts
@@ -44,6 +44,17 @@ export default {
           title: "RSI(14)",
           params: { lookbackPeriods: 14 },
           results: ["rsi"]
+        },
+        bb: {
+          uiid: "BB",
+          title: "Bollinger Bands(20,2)",
+          params: { lookbackPeriods: 20, standardDeviations: 2 }
+        },
+        bbPctB: {
+          uiid: "BB-PCTB",
+          title: "Bollinger Bands %B(20,2)",
+          params: { lookbackPeriods: 20, standardDeviations: 2 },
+          results: ["percentB"]
         }
       }
     });

--- a/tests/vitepress/examples/indicators.md
+++ b/tests/vitepress/examples/indicators.md
@@ -106,6 +106,67 @@ manager.createOscillator(rsiCanvas, selection, listing);
 
 :::
 
+## Overlay indicator + companion oscillator (aligned)
+
+Compose an **overlay indicator on the price panel** with its **companion oscillator** beneath it — in a single, vertically aligned chart — by adding the `with` prop. Both indicators share one `ChartManager`, so the oscillator's x-axis lines up with the price panel above it.
+
+<ClientOnly>
+  <StockIndicatorChart indicator="bb" with="bbPctB" id="bb-combo" />
+</ClientOnly>
+
+::: code-group
+
+```vue [Vue / VitePress]
+<ClientOnly>
+  <StockIndicatorChart indicator="bb" with="bbPctB" />
+</ClientOnly>
+```
+
+> [!tip]
+> `with` accepts a single indicator name or an array (`:with="['bbPctB', 'rsi']"`). Overlay-type companions render on the price panel; oscillator-type companions each get an aligned pane beneath it.
+
+```typescript [Plain TypeScript]
+import {
+  ChartManager,
+  createApiClient,
+  createDefaultSelection,
+  loadStaticIndicatorData,
+  setupIndyCharts
+} from "@facioquo/indy-charts";
+
+setupIndyCharts();
+
+const api = createApiClient({ baseUrl: "https://api.example.com" });
+const [quotes, listings] = await Promise.all([api.getQuotes(), api.getListings()]);
+
+const bbListing = listings.find(l => l.uiid === "BB")!;
+const pctbListing = listings.find(l => l.uiid === "BB-PCTB")!;
+const bb = createDefaultSelection(bbListing, { lookbackPeriods: 20, standardDeviations: 2 });
+const pctb = createDefaultSelection(pctbListing, { lookbackPeriods: 20, standardDeviations: 2 });
+
+const priceCanvas = document.getElementById("price-chart") as HTMLCanvasElement;
+const pctbCanvas = document.getElementById("pctb-chart") as HTMLCanvasElement;
+
+const manager = new ChartManager({ settings: { isDarkTheme: false, showTooltips: true } });
+
+// One manager drives both panels so they share the windowed x-axis.
+manager.initializeOverlay(priceCanvas, quotes, 250);
+
+// Bands render on the price panel.
+manager.processSelectionData(bb, bbListing, loadStaticIndicatorData(await api.getSelectionData(bb, bbListing)));
+manager.displaySelection(bb, bbListing);
+
+// %B renders in an aligned oscillator pane below.
+manager.processSelectionData(pctb, pctbListing, loadStaticIndicatorData(await api.getSelectionData(pctb, pctbListing)));
+manager.displaySelection(pctb, pctbListing);
+manager.createOscillator(pctbCanvas, pctb, pctbListing);
+```
+
+:::
+
+> [!warning] Alignment contract
+> X-axis alignment is only guaranteed when both panels are driven by **one** component (or one `ChartManager`). Stacking two **separate** `<StockIndicatorChart>` instances does not link their x-axis geometry — a standalone oscillator auto-ranges to its own data independently of any sibling chart. Use `with` (or `:with-overlay="true"`) to keep panels aligned.
+
 ## Custom parameters
 
 Use the `config` prop to override registered indicator parameters:

--- a/tests/vitepress/guide/quick-start.md
+++ b/tests/vitepress/guide/quick-start.md
@@ -166,6 +166,17 @@ Have a single component render **both** the price chart and the oscillator stack
 
 The instance manages its own price/volume canvas above the RSI panel; it does not look at adjacent siblings.
 
+To pair an **overlay indicator** (e.g. Bollinger Bands) with its **companion oscillator** (e.g. %B) in one aligned chart, use the `with` prop — both render under a single `ChartManager`, sharing the price panel's x-axis:
+
+```vue
+<ClientOnly>
+  <StockIndicatorChart indicator="bb" with="bbPctB" />
+</ClientOnly>
+```
+
+> [!warning]
+> X-axis alignment requires **one** component (one `ChartManager`). Two separate `<StockIndicatorChart>` instances stacked on a page do not share x-axis geometry — a standalone oscillator auto-ranges to its own data. Use `with` or `:with-overlay="true"` to keep panels aligned.
+
 ## What's next?
 
 - See the [overlay example](/examples/) for a working live demo


### PR DESCRIPTION
## Summary

Implements GitHub issues #494, #495, and #496 for `@facioquo/indy-charts`. These are interrelated: #496 is the clean fix for the cross-component misalignment in #494, and #495 is an independent oscillator-axis fix.

### #496 — compose an overlay indicator + companion oscillator in one component
A single `<StockIndicatorChart>` can now compose an overlay indicator on the price panel with its companion oscillator beneath it, vertically aligned, via a new **`with`** prop (`string | string[]`, also readable from `config.with`).

- Resolves the primary indicator plus `with` companions, loads them under **one** `ChartManager`.
- Routes each selection to the correct panel by `listing.chartType` (overlay → shared price panel; oscillator → its own aligned pane).
- Renders N oscillator canvases; `needsOverlay` becomes automatic when any overlay indicator is present.
- The first/single oscillator keeps its existing `-oscillator-canvas` testid for backward compatibility.

```vue
<StockIndicatorChart indicator="bb" with="bbPctB" />
```

### #494 — alignment contract
Documents that x-axis alignment requires **one** component / one `ChartManager` — two separate stacked `<StockIndicatorChart>` instances do not share x-axis geometry. The `with` prop is the supported fix.

### #495 — oscillator right y-axis labels usually not visible
The y-tick callback no longer unconditionally drops the first and last labels. It only trims the boundary labels once the pane has enough gridlines (`MIN_TICKS_TO_TRIM_BOUNDS = 4`), so short panes (`aspect-ratio: 6`) still show their bounds. Mirror behavior is unchanged, preserving x-axis alignment with the overlay.

## Changes
- `vue/stock-indicator-chart.ts`: multi-indicator load/render + `with` prop.
- `vue/types.ts`: documented `with` on config and props.
- `config/oscillator.ts`: conditional boundary-tick trimming.
- Docs: registered `bb`/`bbPctB`; new composed example + alignment warning in `examples/indicators.md` and `guide/quick-start.md`.
- Tests: new `config/oscillator.spec.ts`; composition unit tests; Playwright BB/%B mocks + a test asserting overlay/oscillator canvases share the same `x` and `width`.

## Verification
- indy-charts: lint ✅, 176 unit tests ✅, `format:check` ✅, markdownlint ✅, VitePress SSR build ✅.
- Verified end-to-end in a real browser against the built docs: the composed chart's overlay and oscillator canvases reported identical `x` (294) and `width` (666) with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)