### PR TITLE
feat: Add Gator, pivots, and quote transform overlays

### DIFF
--- a/client/src/app/data/backup-indicators.json
+++ b/client/src/app/data/backup-indicators.json
@@ -1602,6 +1602,41 @@
     ]
   },
   {
+    "name": "Gator Oscillator",
+    "uiid": "GATOR",
+    "legendTemplate": "GATOR",
+    "endpoint": "/GATOR/",
+    "category": "price-trend",
+    "chartType": "oscillator",
+    "order": 1,
+    "chartConfig": null,
+    "parameters": [],
+    "results": [
+      {
+        "displayName": "Upper",
+        "tooltipTemplate": "Upper",
+        "dataName": "upper",
+        "dataType": "number",
+        "lineType": "bar",
+        "stack": "gator",
+        "lineWidth": 2,
+        "defaultColor": "#2E7D32",
+        "fill": null
+      },
+      {
+        "displayName": "Lower",
+        "tooltipTemplate": "Lower",
+        "dataName": "lower",
+        "dataType": "number",
+        "lineType": "bar",
+        "stack": "gator",
+        "lineWidth": 2,
+        "defaultColor": "#DD2C00",
+        "fill": null
+      }
+    ]
+  },
+  {
     "name": "Hilbert Transform Instantaneous Trendline",
     "uiid": "HT Trendline",
     "legendTemplate": "HT TRENDLINE",
@@ -2583,6 +2618,178 @@
     ]
   },
   {
+    "name": "Pivot Points (week)",
+    "uiid": "PIVOT-POINTS",
+    "legendTemplate": "PIVOT POINTS(WEEK)",
+    "endpoint": "/PIVOT-POINTS/",
+    "category": "price-channel",
+    "chartType": "overlay",
+    "order": 1,
+    "chartConfig": null,
+    "parameters": [],
+    "results": [
+      {
+        "displayName": "R3",
+        "tooltipTemplate": "Resistance 3",
+        "dataName": "r3",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#DD2C00",
+        "fill": null
+      },
+      {
+        "displayName": "R2",
+        "tooltipTemplate": "Resistance 2",
+        "dataName": "r2",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#DD2C00",
+        "fill": null
+      },
+      {
+        "displayName": "R1",
+        "tooltipTemplate": "Resistance 1",
+        "dataName": "r1",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#DD2C00",
+        "fill": null
+      },
+      {
+        "displayName": "Pivot Point",
+        "tooltipTemplate": "Pivot Point",
+        "dataName": "pp",
+        "dataType": "number",
+        "lineType": "solid",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#1E88E5",
+        "fill": null
+      },
+      {
+        "displayName": "S1",
+        "tooltipTemplate": "Support 1",
+        "dataName": "s1",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#2E7D32",
+        "fill": null
+      },
+      {
+        "displayName": "S2",
+        "tooltipTemplate": "Support 2",
+        "dataName": "s2",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#2E7D32",
+        "fill": null
+      },
+      {
+        "displayName": "S3",
+        "tooltipTemplate": "Support 3",
+        "dataName": "s3",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#2E7D32",
+        "fill": null
+      }
+    ]
+  },
+  {
+    "name": "Pivots (Williams Fractal)",
+    "uiid": "PIVOTS",
+    "legendTemplate": "PIVOTS([P1],[P2],[P3])",
+    "endpoint": "/PIVOTS/",
+    "category": "price-pattern",
+    "chartType": "overlay",
+    "order": 1,
+    "chartConfig": null,
+    "parameters": [
+      {
+        "displayName": "Left Span",
+        "paramName": "leftSpan",
+        "dataType": "int",
+        "minimum": 2,
+        "maximum": 50,
+        "defaultValue": 2
+      },
+      {
+        "displayName": "Right Span",
+        "paramName": "rightSpan",
+        "dataType": "int",
+        "minimum": 2,
+        "maximum": 50,
+        "defaultValue": 2
+      },
+      {
+        "displayName": "Max Trend Periods",
+        "paramName": "maxTrendPeriods",
+        "dataType": "int",
+        "minimum": 3,
+        "maximum": 250,
+        "defaultValue": 20
+      }
+    ],
+    "results": [
+      {
+        "displayName": "High Point",
+        "tooltipTemplate": "High Point",
+        "dataName": "highPoint",
+        "dataType": "number",
+        "lineType": "dots",
+        "stack": null,
+        "lineWidth": 3,
+        "defaultColor": "#DD2C00",
+        "fill": null
+      },
+      {
+        "displayName": "Low Point",
+        "tooltipTemplate": "Low Point",
+        "dataName": "lowPoint",
+        "dataType": "number",
+        "lineType": "dots",
+        "stack": null,
+        "lineWidth": 3,
+        "defaultColor": "#2E7D32",
+        "fill": null
+      },
+      {
+        "displayName": "High Trend Line",
+        "tooltipTemplate": "High Trend Line",
+        "dataName": "highLine",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#DD2C00",
+        "fill": null
+      },
+      {
+        "displayName": "Low Trend Line",
+        "tooltipTemplate": "Low Trend Line",
+        "dataName": "lowLine",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#2E7D32",
+        "fill": null
+      }
+    ]
+  },
+  {
     "name": "Price Momentum Oscillator (PMO)",
     "uiid": "PMO",
     "legendTemplate": "PMO([P1],[P2],[P3])",
@@ -2833,6 +3040,113 @@
         "stack": null,
         "lineWidth": 2,
         "defaultColor": "#1E88E5",
+        "fill": null
+      }
+    ]
+  },
+  {
+    "name": "Rolling Pivot Points",
+    "uiid": "ROLLING-PIVOTS",
+    "legendTemplate": "ROLLING PIVOTS([P1],[P2])",
+    "endpoint": "/ROLLING-PIVOTS/",
+    "category": "price-channel",
+    "chartType": "overlay",
+    "order": 1,
+    "chartConfig": null,
+    "parameters": [
+      {
+        "displayName": "Window Periods",
+        "paramName": "windowPeriods",
+        "dataType": "int",
+        "minimum": 1,
+        "maximum": 250,
+        "defaultValue": 11
+      },
+      {
+        "displayName": "Offset Periods",
+        "paramName": "offsetPeriods",
+        "dataType": "int",
+        "minimum": 0,
+        "maximum": 250,
+        "defaultValue": 9
+      }
+    ],
+    "results": [
+      {
+        "displayName": "R3",
+        "tooltipTemplate": "Resistance 3",
+        "dataName": "r3",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#DD2C00",
+        "fill": null
+      },
+      {
+        "displayName": "R2",
+        "tooltipTemplate": "Resistance 2",
+        "dataName": "r2",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#DD2C00",
+        "fill": null
+      },
+      {
+        "displayName": "R1",
+        "tooltipTemplate": "Resistance 1",
+        "dataName": "r1",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#DD2C00",
+        "fill": null
+      },
+      {
+        "displayName": "Pivot Point",
+        "tooltipTemplate": "Pivot Point",
+        "dataName": "pp",
+        "dataType": "number",
+        "lineType": "solid",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#1E88E5",
+        "fill": null
+      },
+      {
+        "displayName": "S1",
+        "tooltipTemplate": "Support 1",
+        "dataName": "s1",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#2E7D32",
+        "fill": null
+      },
+      {
+        "displayName": "S2",
+        "tooltipTemplate": "Support 2",
+        "dataName": "s2",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#2E7D32",
+        "fill": null
+      },
+      {
+        "displayName": "S3",
+        "tooltipTemplate": "Support 3",
+        "dataName": "s3",
+        "dataType": "number",
+        "lineType": "dash",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#2E7D32",
         "fill": null
       }
     ]

--- a/client/src/app/data/backup-indicators.json
+++ b/client/src/app/data/backup-indicators.json
@@ -371,6 +371,30 @@
     ]
   },
   {
+    "name": "Average Price (OHLC4)",
+    "uiid": "OHLC4",
+    "legendTemplate": "OHLC4",
+    "endpoint": "/OHLC4/",
+    "category": "price-transform",
+    "chartType": "overlay",
+    "order": 1,
+    "chartConfig": null,
+    "parameters": [],
+    "results": [
+      {
+        "displayName": "OHLC4",
+        "tooltipTemplate": "OHLC4",
+        "dataName": "value",
+        "dataType": "number",
+        "lineType": "solid",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#1E88E5",
+        "fill": null
+      }
+    ]
+  },
+  {
     "name": "Average True Range (ATR)",
     "uiid": "ATR",
     "legendTemplate": "ATR([P1])",
@@ -2081,6 +2105,30 @@
     ]
   },
   {
+    "name": "Median Price (HL2)",
+    "uiid": "HL2",
+    "legendTemplate": "HL2",
+    "endpoint": "/HL2/",
+    "category": "price-transform",
+    "chartType": "overlay",
+    "order": 1,
+    "chartConfig": null,
+    "parameters": [],
+    "results": [
+      {
+        "displayName": "HL2",
+        "tooltipTemplate": "HL2",
+        "dataName": "value",
+        "dataType": "number",
+        "lineType": "solid",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#1E88E5",
+        "fill": null
+      }
+    ]
+  },
+  {
     "name": "MESA Adaptive Moving Average (MAMA)",
     "uiid": "MAMA",
     "legendTemplate": "MAMA([P1],[P2])",
@@ -2354,6 +2402,54 @@
         "displayName": "OBV",
         "tooltipTemplate": "OBV",
         "dataName": "obv",
+        "dataType": "number",
+        "lineType": "solid",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#1E88E5",
+        "fill": null
+      }
+    ]
+  },
+  {
+    "name": "Open-Close Average (OC2)",
+    "uiid": "OC2",
+    "legendTemplate": "OC2",
+    "endpoint": "/OC2/",
+    "category": "price-transform",
+    "chartType": "overlay",
+    "order": 1,
+    "chartConfig": null,
+    "parameters": [],
+    "results": [
+      {
+        "displayName": "OC2",
+        "tooltipTemplate": "OC2",
+        "dataName": "value",
+        "dataType": "number",
+        "lineType": "solid",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#1E88E5",
+        "fill": null
+      }
+    ]
+  },
+  {
+    "name": "Open-High-Low Average (OHL3)",
+    "uiid": "OHL3",
+    "legendTemplate": "OHL3",
+    "endpoint": "/OHL3/",
+    "category": "price-transform",
+    "chartType": "overlay",
+    "order": 1,
+    "chartConfig": null,
+    "parameters": [],
+    "results": [
+      {
+        "displayName": "OHL3",
+        "tooltipTemplate": "OHL3",
+        "dataName": "value",
         "dataType": "number",
         "lineType": "solid",
         "stack": null,
@@ -3671,6 +3767,30 @@
         "stack": null,
         "lineWidth": 2,
         "defaultColor": "#DD2C00",
+        "fill": null
+      }
+    ]
+  },
+  {
+    "name": "Typical Price (HLC3)",
+    "uiid": "HLC3",
+    "legendTemplate": "HLC3",
+    "endpoint": "/HLC3/",
+    "category": "price-transform",
+    "chartType": "overlay",
+    "order": 1,
+    "chartConfig": null,
+    "parameters": [],
+    "results": [
+      {
+        "displayName": "HLC3",
+        "tooltipTemplate": "HLC3",
+        "dataName": "value",
+        "dataType": "number",
+        "lineType": "solid",
+        "stack": null,
+        "lineWidth": 2,
+        "defaultColor": "#1E88E5",
         "fill": null
       }
     ]

--- a/client/src/app/data/backup-indicators.json
+++ b/client/src/app/data/backup-indicators.json
@@ -1549,7 +1549,7 @@
         "tooltipTemplate": "FORCE([P1])",
         "dataName": "forceIndex",
         "dataType": "number",
-        "lineType": "solid",
+        "lineType": "bar",
         "stack": null,
         "lineWidth": 2,
         "defaultColor": "#1E88E5",

--- a/libs/indy-charts/charts/chart-manager.spec.ts
+++ b/libs/indy-charts/charts/chart-manager.spec.ts
@@ -422,6 +422,59 @@ describe("ChartManager", () => {
       expect(selection.results[0].dataset.data.length).toBeGreaterThan(0);
     });
 
+    it("colors histogram bars per the <dataName>IsExpanding flags", () => {
+      // Gator-style oscillator: two bar histograms whose color encodes whether
+      // each bar is expanding (green) or contracting (red), per the standard
+      // depiction — not a single static color per series.
+      const listing = makeOscillatorListing({
+        uiid: "GATOR",
+        category: "price-trend",
+        chartConfig: null,
+        parameters: [],
+        results: [
+          {
+            dataName: "upper",
+            displayName: "Upper",
+            tooltipTemplate: "Upper",
+            defaultColor: "#2E7D32",
+            lineType: "bar",
+            lineWidth: 2,
+            dataType: "number",
+            stack: "gator",
+            order: 1
+          },
+          {
+            dataName: "lower",
+            displayName: "Lower",
+            tooltipTemplate: "Lower",
+            defaultColor: "#DD2C00",
+            lineType: "bar",
+            lineWidth: 2,
+            dataType: "number",
+            stack: "gator",
+            order: 2
+          }
+        ]
+      });
+      const selection = makeSelection(listing, "gator-1");
+      const quotes = makeQuotes(4);
+      const data: IndicatorDataRow[] = quotes.map((q, i) => ({
+        timestamp: new Date(q.timestamp).toISOString(),
+        upper: 5 + i,
+        lower: -(5 + i),
+        upperIsExpanding: i % 2 === 0,
+        lowerIsExpanding: i % 2 === 1
+      }));
+
+      mgr.processSelectionData(selection, listing, data);
+
+      const upperBg = selection.results[0].dataset.backgroundColor as string[];
+      const lowerBg = selection.results[1].dataset.backgroundColor as string[];
+      expect(selection.results[0].dataset.type).toBe("bar");
+      expect(upperBg.slice(0, 4)).toEqual(["#2E7D32", "#DD2C00", "#2E7D32", "#DD2C00"]);
+      expect(lowerBg.slice(0, 4)).toEqual(["#DD2C00", "#2E7D32", "#DD2C00", "#2E7D32"]);
+    });
+
     it("stores a deep copy for later resizing", () => {
       const listing = makeOverlayListing();
       const selection = makeSelection(listing, "sel-2");

--- a/libs/indy-charts/charts/chart-manager.spec.ts
+++ b/libs/indy-charts/charts/chart-manager.spec.ts
@@ -830,6 +830,50 @@ describe("ChartManager", () => {
       expect(slicedLength).toBeLessThanOrEqual(20 + 6); // +6 for extraBars
     });
 
+    it("slices a bar dataset's backgroundColor array in sync with the window", () => {
+      const ctx = {} as CanvasRenderingContext2D;
+      const quotes = makeQuotes(100);
+      mgr.initializeOverlay(ctx, quotes, 50);
+
+      // Overlay bar histogram with per-bar expanding/contracting colors. The
+      // backgroundColor array must follow the window like the data and point
+      // arrays, otherwise colors would shift relative to the visible bars.
+      const listing = makeOverlayListing({
+        uiid: "GATOR-OVERLAY",
+        category: "price-trend",
+        parameters: [],
+        results: [
+          {
+            dataName: "upper",
+            displayName: "Upper",
+            tooltipTemplate: "Upper",
+            defaultColor: "#000000",
+            lineType: "bar",
+            lineWidth: 2,
+            dataType: "number",
+            stack: "g",
+            order: 1
+          }
+        ]
+      });
+      const selection = makeSelection(listing, "bg-slice");
+      const data: IndicatorDataRow[] = quotes.map((q, i) => ({
+        timestamp: new Date(q.timestamp).toISOString(),
+        upper: i,
+        upperIsExpanding: i % 2 === 0
+      }));
+      mgr.processSelectionData(selection, listing, data);
+      mgr.displaySelection(selection, listing);
+
+      mgr.setBarCount(20);
+
+      // startIndex = 100 - 20 = 80; the color array (one per quote, no extra
+      // bars) slices to 20 entries, still aligned to the visible bars.
+      const bg = selection.results[0].dataset.backgroundColor as string[];
+      expect(bg).toHaveLength(20);
+      expect(bg[0]).toBe("#2E7D32"); // quote 80 is expanding → green
+    });
+
     it("updates oscillator charts via applySlicedData", () => {
       const ctx = {} as CanvasRenderingContext2D;
       const quotes = makeQuotes(100);

--- a/libs/indy-charts/charts/chart-manager.ts
+++ b/libs/indy-charts/charts/chart-manager.ts
@@ -206,8 +206,8 @@ export class ChartManager {
     if (!this._overlayChart) return;
 
     // Slice indicator datasets to currentBarCount before adding to the windowed chart.
-    // Also slice style arrays (pointBackgroundColor, pointBorderColor, pointRotation)
-    // to keep them synchronized with the data length.
+    // Also slice style arrays (pointBackgroundColor, pointBorderColor, pointRotation,
+    // and bar backgroundColor) to keep them synchronized with the data length.
     const fullDatasets = this._allProcessedDatasets.get(selection.ucid);
     if (fullDatasets) {
       const startIndex = Math.max(0, this._allQuotes.length - this._currentBarCount);
@@ -229,6 +229,12 @@ export class ChartManager {
           }
           if (Array.isArray(full.pointRotation)) {
             ext.pointRotation = [...(full.pointRotation as number[]).slice(startIndex)];
+          }
+          // Bar histograms (e.g. expanding/contracting series) carry a per-bar
+          // backgroundColor array; slice it alongside the data so colors stay
+          // aligned with the visible window.
+          if (Array.isArray(full.backgroundColor)) {
+            ext.backgroundColor = [...(full.backgroundColor as string[]).slice(startIndex)];
           }
         }
       });
@@ -379,8 +385,8 @@ export class ChartManager {
     // Update overlay indicator datasets to stay aligned with the windowed x-axis.
     // Mirror the oscillator loop below but for OVERLAY selections: retrieve each
     // indicator's full dataset from allProcessedDatasets and slice to startIndex.
-    // Also slice style arrays (pointBackgroundColor, pointBorderColor, pointRotation)
-    // to keep them synchronized with the data length.
+    // Also slice style arrays (pointBackgroundColor, pointBorderColor, pointRotation,
+    // and bar backgroundColor) to keep them synchronized with the data length.
     let overlayIndicatorsUpdated = false;
     this._selections.forEach(selection => {
       if (selection.chartType !== CHART_TYPES.OVERLAY) return;
@@ -403,6 +409,12 @@ export class ChartManager {
           }
           if (Array.isArray(full.pointRotation)) {
             ext.pointRotation = [...(full.pointRotation as number[]).slice(startIndex)];
+          }
+          // Bar histograms (e.g. expanding/contracting series) carry a per-bar
+          // backgroundColor array; slice it alongside the data so colors stay
+          // aligned with the visible window.
+          if (Array.isArray(full.backgroundColor)) {
+            ext.backgroundColor = [...(full.backgroundColor as string[]).slice(startIndex)];
           }
         }
       });

--- a/libs/indy-charts/charts/chart-manager.ts
+++ b/libs/indy-charts/charts/chart-manager.ts
@@ -24,10 +24,6 @@ const CHART_TYPES = {
   OSCILLATOR: "oscillator"
 } as const;
 
-const CATEGORIES = {
-  CANDLESTICK_PATTERN: "candlestick-pattern"
-} as const;
-
 /**
  * Reserved cache key for the overlay's candlestick + volume datasets in
  * `_allProcessedDatasets`. No `IndicatorSelection.ucid` may collide with this
@@ -144,14 +140,25 @@ export class ChartManager {
       if (!resultConfig) return;
 
       const dataset = baseDataset(result, resultConfig);
-      const { dataPoints, pointColor, pointRotation } = buildDataPoints(data, result, listing);
+      const { dataPoints, pointColor, pointRotation, hasConditionalColor } = buildDataPoints(
+        data,
+        result,
+        listing
+      );
       addExtraBars(dataPoints, this.extraBars);
 
-      if (listing.category === CATEGORIES.CANDLESTICK_PATTERN && dataset.type !== "bar") {
+      // Per-point coloring: candlestick-pattern markers and expanding/contracting
+      // histograms (e.g. Gator) vary color per row. Bars apply it via
+      // `backgroundColor`; point/line series via the point color arrays.
+      if (hasConditionalColor) {
         const ext = dataset as ExtendedChartDataset;
-        ext.pointRotation = pointRotation;
-        ext.pointBackgroundColor = pointColor;
-        ext.pointBorderColor = pointColor;
+        if (dataset.type === "bar") {
+          ext.backgroundColor = pointColor;
+        } else {
+          ext.pointRotation = pointRotation;
+          ext.pointBackgroundColor = pointColor;
+          ext.pointBorderColor = pointColor;
+        }
       }
 
       dataset.data = dataPoints;

--- a/libs/indy-charts/data/transformers.spec.ts
+++ b/libs/indy-charts/data/transformers.spec.ts
@@ -277,6 +277,75 @@ describe("buildDataPoints", () => {
     expect(pointRotation[0]).toBe(0);
   });
 
+  // Expanding/contracting histogram tests (e.g. Gator Oscillator)
+
+  it("colors expanding histogram bars green and contracting bars red", () => {
+    const data: IndicatorDataRow[] = [
+      { timestamp: "2024-01-01", upper: 5, upperIsExpanding: true },
+      { timestamp: "2024-01-02", upper: 3, upperIsExpanding: false }
+    ];
+    const result = makeResult({ dataName: "upper" });
+    const listing = makeListing({
+      category: "price-trend",
+      results: [
+        {
+          displayName: "Upper",
+          tooltipTemplate: "",
+          dataName: "upper",
+          dataType: "number",
+          lineType: "bar",
+          stack: "gator",
+          lineWidth: 2,
+          defaultColor: "#000000",
+          order: 0
+        }
+      ]
+    });
+
+    const { pointColor, hasConditionalColor } = buildDataPoints(data, result, listing);
+
+    expect(hasConditionalColor).toBe(true);
+    expect(pointColor[0]).toBe("#2E7D32"); // COLORS.GREEN (expanding)
+    expect(pointColor[1]).toBe("#DD2C00"); // COLORS.RED (contracting)
+  });
+
+  it("uses the static color and flags no conditional color without an expanding field", () => {
+    const data = [makeRow("2024-01-01", { sma: 50 })];
+    const result = makeResult({ dataName: "sma" });
+    const listing = makeListing({ category: "overlay" });
+
+    const { pointColor, hasConditionalColor } = buildDataPoints(data, result, listing);
+
+    expect(hasConditionalColor).toBe(false);
+    expect(pointColor[0]).toBe("#FF0000"); // listing result defaultColor
+  });
+
+  it("ignores a non-boolean expanding field and falls back to the static color", () => {
+    const data: IndicatorDataRow[] = [{ timestamp: "2024-01-01", upper: 5, upperIsExpanding: 1 }];
+    const result = makeResult({ dataName: "upper" });
+    const listing = makeListing({
+      category: "price-trend",
+      results: [
+        {
+          displayName: "Upper",
+          tooltipTemplate: "",
+          dataName: "upper",
+          dataType: "number",
+          lineType: "bar",
+          stack: "gator",
+          lineWidth: 2,
+          defaultColor: "#123456",
+          order: 0
+        }
+      ]
+    });
+
+    const { pointColor, hasConditionalColor } = buildDataPoints(data, result, listing);
+
+    expect(hasConditionalColor).toBe(false);
+    expect(pointColor[0]).toBe("#123456");
+  });
+
   it("throws when a row is missing `timestamp`", () => {
     const data: IndicatorDataRow[] = [{ candle: makeQuote("2024-01-01"), sma: 50 }];
     const result = makeResult({ dataName: "sma" });

--- a/libs/indy-charts/data/transformers.ts
+++ b/libs/indy-charts/data/transformers.ts
@@ -48,10 +48,12 @@ export function buildDataPoints(
   dataPoints: ScatterDataPoint[];
   pointColor: string[];
   pointRotation: number[];
+  hasConditionalColor: boolean;
 } {
   const dataPoints: ScatterDataPoint[] = [];
   const pointColor: string[] = [];
   const pointRotation: number[] = [];
+  let hasConditionalColor = false;
 
   data.forEach(row => {
     const rawValue: unknown = row[result.dataName];
@@ -66,9 +68,20 @@ export function buildDataPoints(
       yValue = candleConfig.yValue;
       pointColor.push(candleConfig.color);
       pointRotation.push(candleConfig.rotation);
+      hasConditionalColor = true;
     } else {
-      const resultConfig = listing.results.find(x => x.dataName === result.dataName);
-      pointColor.push(resultConfig?.defaultColor ?? COLORS.GRAY);
+      // expanding/contracting series (e.g. the Gator Oscillator) carry a
+      // companion `<dataName>IsExpanding` boolean per row; color each bar green
+      // while the histogram is widening and red while it is narrowing — the
+      // standard depiction — rather than a single static series color.
+      const expandingColor = resolveExpandingColor(row, result.dataName);
+      if (expandingColor) {
+        pointColor.push(expandingColor);
+        hasConditionalColor = true;
+      } else {
+        const resultConfig = listing.results.find(x => x.dataName === result.dataName);
+        pointColor.push(resultConfig?.defaultColor ?? COLORS.GRAY);
+      }
       pointRotation.push(0);
     }
 
@@ -87,7 +100,22 @@ export function buildDataPoints(
     dataPoints.push({ x, y: yValue });
   });
 
-  return { dataPoints, pointColor, pointRotation };
+  return { dataPoints, pointColor, pointRotation, hasConditionalColor };
+}
+
+/**
+ * Resolve the per-bar color for an expanding/contracting histogram series.
+ *
+ * Series such as the Gator Oscillator expose a `<dataName>IsExpanding` boolean
+ * alongside each value (e.g. `upper` → `upperIsExpanding`). When present, the
+ * bar is green while the value is growing and red while it is shrinking.
+ * Returns `undefined` for series without the companion flag so callers fall
+ * back to the configured static color.
+ */
+function resolveExpandingColor(row: IndicatorDataRow, dataName: string): string | undefined {
+  const flag = row[`${dataName}IsExpanding`];
+  if (typeof flag !== "boolean") return undefined;
+  return flag ? COLORS.GREEN : COLORS.RED;
 }
 
 export function addExtraBars(dataPoints: ScatterDataPoint[], extraBars: number): void {

--- a/scripts/smoke-indy-charts-vitepress-consumer.js
+++ b/scripts/smoke-indy-charts-vitepress-consumer.js
@@ -16,7 +16,8 @@ if (!pnpmCli) {
 function runPnpm(args, cwd = workspaceRoot) {
   // pnpm may be a native binary (e.g. @pnpm/exe) rather than a JS wrapper.
   // Run it directly in that case; otherwise invoke it via Node.js.
-  const isJsWrapper = pnpmCli.endsWith(".js") || pnpmCli.endsWith(".cjs");
+  const isJsWrapper =
+    pnpmCli.endsWith(".js") || pnpmCli.endsWith(".cjs") || pnpmCli.endsWith(".mjs");
   const cmd = isJsWrapper ? process.execPath : pnpmCli;
   const cmdArgs = isJsWrapper ? [pnpmCli, ...args] : args;
   const result = spawnSync(cmd, cmdArgs, {
@@ -29,9 +30,7 @@ function runPnpm(args, cwd = workspaceRoot) {
   }
 
   if (result.status !== 0) {
-    throw new Error(
-      `pnpm ${args.join(" ")} failed with exit code ${result.status ?? "unknown"}`
-    );
+    throw new Error(`pnpm ${args.join(" ")} failed with exit code ${result.status ?? "unknown"}`);
   }
 }
 
@@ -76,7 +75,7 @@ try {
           "chartjs-plugin-annotation": "3.1.0",
           vitepress: "2.0.0-alpha.16",
           vue: "3.5.33"
-        },
+        }
       },
       null,
       2

--- a/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
+++ b/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
@@ -411,6 +411,117 @@ public class MainEndpointsTests
             Assert.Equal((double)(pair.Second.Open + pair.Second.High + pair.Second.Low + pair.Second.Close) / 4, pair.First.Value, 6));
     }
 
+    [Fact]
+    public async Task GetGator_WithValidQuotes_ReturnsOkResult()
+    {
+        // Arrange — Gator derives from the Alligator, which needs ~121 periods
+        // of warmup, so generate well beyond that.
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act
+        IActionResult result = await _controller.GetGator();
+
+        // Assert — the catalog exposes upper/lower histograms; confirm the
+        // endpoint returns the GatorResult series for the visible window.
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<GatorResult> gator = Assert.IsAssignableFrom<IEnumerable<GatorResult>>(okResult.Value).ToList();
+        Assert.Equal(120, gator.Count);
+    }
+
+    [Fact]
+    public async Task GetPivotPoints_WithValidQuotes_ReturnsOkResult()
+    {
+        // Arrange — weekly pivot points need at least two windows of warmup.
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act
+        IActionResult result = await _controller.GetPivotPoints();
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<PivotPointsResult> pivots = Assert.IsAssignableFrom<IEnumerable<PivotPointsResult>>(okResult.Value).ToList();
+        Assert.Equal(120, pivots.Count);
+    }
+
+    [Fact]
+    public async Task GetPivots_WithValidParameters_ReturnsOkResult()
+    {
+        // Arrange
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act — leftSpan, rightSpan, maxTrendPeriods
+        IActionResult result = await _controller.GetPivots(2, 2, 20);
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<PivotsResult> pivots = Assert.IsAssignableFrom<IEnumerable<PivotsResult>>(okResult.Value).ToList();
+        Assert.Equal(120, pivots.Count);
+    }
+
+    [Fact]
+    public async Task GetPivots_WithInvalidParameters_ReturnsBadRequest()
+    {
+        // Arrange
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act — maxTrendPeriods must exceed leftSpan; the library throws and the
+        // Get<T> helper surfaces it as a 400 rather than a 500.
+        IActionResult result = await _controller.GetPivots(2, 2, 1);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetRollingPivots_WithValidParameters_ReturnsOkResult()
+    {
+        // Arrange
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act — windowPeriods, offsetPeriods
+        IActionResult result = await _controller.GetRollingPivots(11, 9);
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<RollingPivotsResult> pivots = Assert.IsAssignableFrom<IEnumerable<RollingPivotsResult>>(okResult.Value).ToList();
+        Assert.Equal(120, pivots.Count);
+    }
+
     /// <summary>
     /// Helper to generate sample quote data for tests.
     /// </summary>

--- a/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
+++ b/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
@@ -289,6 +289,128 @@ public class MainEndpointsTests
         Assert.Empty(vwap);
     }
 
+    [Fact]
+    public async Task GetHl2_ComputesMedianPrice_ReturnsOkResult()
+    {
+        // Arrange — HL2 = (high + low) / 2. With the sample generator
+        // (high = base + 2, low = base - 2) the median collapses to base.
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act
+        IActionResult result = await _controller.GetHl2();
+
+        // Assert — the visible window carries the limitLast slice, every value
+        // computed from the expected (high + low) / 2 formula.
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<TimeValue> values = Assert.IsAssignableFrom<IEnumerable<TimeValue>>(okResult.Value).ToList();
+        Assert.Equal(120, values.Count);
+        Assert.All(values.Zip(sampleQuotes.TakeLast(120)), pair =>
+            Assert.Equal((double)(pair.Second.High + pair.Second.Low) / 2, pair.First.Value, 6));
+    }
+
+    [Fact]
+    public async Task GetHlc3_ComputesTypicalPrice_ReturnsOkResult()
+    {
+        // Arrange — HLC3 = (high + low + close) / 3.
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act
+        IActionResult result = await _controller.GetHlc3();
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<TimeValue> values = Assert.IsAssignableFrom<IEnumerable<TimeValue>>(okResult.Value).ToList();
+        Assert.Equal(120, values.Count);
+        Assert.All(values.Zip(sampleQuotes.TakeLast(120)), pair =>
+            Assert.Equal((double)(pair.Second.High + pair.Second.Low + pair.Second.Close) / 3, pair.First.Value, 6));
+    }
+
+    [Fact]
+    public async Task GetOc2_ComputesOpenCloseAverage_ReturnsOkResult()
+    {
+        // Arrange — OC2 = (open + close) / 2.
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act
+        IActionResult result = await _controller.GetOc2();
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<TimeValue> values = Assert.IsAssignableFrom<IEnumerable<TimeValue>>(okResult.Value).ToList();
+        Assert.Equal(120, values.Count);
+        Assert.All(values.Zip(sampleQuotes.TakeLast(120)), pair =>
+            Assert.Equal((double)(pair.Second.Open + pair.Second.Close) / 2, pair.First.Value, 6));
+    }
+
+    [Fact]
+    public async Task GetOhl3_ComputesOpenHighLowAverage_ReturnsOkResult()
+    {
+        // Arrange — OHL3 = (open + high + low) / 3.
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act
+        IActionResult result = await _controller.GetOhl3();
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<TimeValue> values = Assert.IsAssignableFrom<IEnumerable<TimeValue>>(okResult.Value).ToList();
+        Assert.Equal(120, values.Count);
+        Assert.All(values.Zip(sampleQuotes.TakeLast(120)), pair =>
+            Assert.Equal((double)(pair.Second.Open + pair.Second.High + pair.Second.Low) / 3, pair.First.Value, 6));
+    }
+
+    [Fact]
+    public async Task GetOhlc4_ComputesAveragePrice_ReturnsOkResult()
+    {
+        // Arrange — OHLC4 = (open + high + low + close) / 4.
+        List<Quote> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act
+        IActionResult result = await _controller.GetOhlc4();
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<TimeValue> values = Assert.IsAssignableFrom<IEnumerable<TimeValue>>(okResult.Value).ToList();
+        Assert.Equal(120, values.Count);
+        Assert.All(values.Zip(sampleQuotes.TakeLast(120)), pair =>
+            Assert.Equal((double)(pair.Second.Open + pair.Second.High + pair.Second.Low + pair.Second.Close) / 4, pair.First.Value, 6));
+    }
+
     /// <summary>
     /// Helper to generate sample quote data for tests.
     /// </summary>

--- a/server/WebApi/Endpoints.cs
+++ b/server/WebApi/Endpoints.cs
@@ -194,6 +194,14 @@ public class Main(IQuoteService quoteService) : ControllerBase
     public Task<IActionResult> GetGator()
         => Get(quotes => quotes.ToGator());
 
+    [HttpGet("HL2")]
+    public Task<IActionResult> GetHl2()
+        => Get(quotes => quotes.Use(CandlePart.HL2));
+
+    [HttpGet("HLC3")]
+    public Task<IActionResult> GetHlc3()
+        => Get(quotes => quotes.Use(CandlePart.HLC3));
+
     [HttpGet("HMA")]
     public Task<IActionResult> GetHma(int lookbackPeriods)
         => Get(quotes => quotes.ToHma(lookbackPeriods));
@@ -245,6 +253,18 @@ public class Main(IQuoteService quoteService) : ControllerBase
     [HttpGet("OBV")]
     public Task<IActionResult> GetObv()
         => Get(quotes => quotes.ToObv());
+
+    [HttpGet("OC2")]
+    public Task<IActionResult> GetOc2()
+        => Get(quotes => quotes.Use(CandlePart.OC2));
+
+    [HttpGet("OHL3")]
+    public Task<IActionResult> GetOhl3()
+        => Get(quotes => quotes.Use(CandlePart.OHL3));
+
+    [HttpGet("OHLC4")]
+    public Task<IActionResult> GetOhlc4()
+        => Get(quotes => quotes.Use(CandlePart.OHLC4));
 
     [HttpGet("PMO")]
     public Task<IActionResult> GetPmo(int timePeriods, int smoothPeriods, int signalPeriods)

--- a/server/WebApi/Endpoints.cs
+++ b/server/WebApi/Endpoints.cs
@@ -266,6 +266,14 @@ public class Main(IQuoteService quoteService) : ControllerBase
     public Task<IActionResult> GetOhlc4()
         => Get(quotes => quotes.Use(CandlePart.OHLC4));
 
+    [HttpGet("PIVOT-POINTS")]
+    public Task<IActionResult> GetPivotPoints()
+        => Get(quotes => quotes.ToPivotPoints(PeriodSize.Week));
+
+    [HttpGet("PIVOTS")]
+    public Task<IActionResult> GetPivots(int leftSpan, int rightSpan, int maxTrendPeriods)
+        => Get(quotes => quotes.ToPivots(leftSpan, rightSpan, maxTrendPeriods));
+
     [HttpGet("PMO")]
     public Task<IActionResult> GetPmo(int timePeriods, int smoothPeriods, int signalPeriods)
         => Get(quotes => quotes.ToPmo(timePeriods, smoothPeriods, signalPeriods));
@@ -285,6 +293,10 @@ public class Main(IQuoteService quoteService) : ControllerBase
     [HttpGet("ROCWB")]
     public Task<IActionResult> GetRocWb(int lookbackPeriods, int emaPeriods, int stdDevPeriods)
         => Get(quotes => quotes.ToRocWb(lookbackPeriods, emaPeriods, stdDevPeriods));
+
+    [HttpGet("ROLLING-PIVOTS")]
+    public Task<IActionResult> GetRollingPivots(int windowPeriods, int offsetPeriods)
+        => Get(quotes => quotes.ToRollingPivots(windowPeriods, offsetPeriods));
 
     [HttpGet("RSI")]
     public Task<IActionResult> GetRsi(int lookbackPeriods)

--- a/server/WebApi/Services/Service.Metadata.cs
+++ b/server/WebApi/Services/Service.Metadata.cs
@@ -3912,6 +3912,106 @@ public static class Metadata
                         DefaultColor = ChartColors.StandardGreen
                     }
                 ]
+            },
+
+            // Quote transform: Median Price (HL2)
+            new IndicatorListing {
+                Name = "Median Price (HL2)",
+                Uiid = "HL2",
+                LegendTemplate = "HL2",
+                Endpoint = $"{baseUrl}/HL2/",
+                Category = "price-transform",
+                ChartType = "overlay",
+                Results = [
+                    new() {
+                        DisplayName = "HL2",
+                        TooltipTemplate = "HL2",
+                        DataName = "value",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    }
+                ]
+            },
+
+            // Quote transform: Typical Price (HLC3)
+            new IndicatorListing {
+                Name = "Typical Price (HLC3)",
+                Uiid = "HLC3",
+                LegendTemplate = "HLC3",
+                Endpoint = $"{baseUrl}/HLC3/",
+                Category = "price-transform",
+                ChartType = "overlay",
+                Results = [
+                    new() {
+                        DisplayName = "HLC3",
+                        TooltipTemplate = "HLC3",
+                        DataName = "value",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    }
+                ]
+            },
+
+            // Quote transform: Open-Close Average (OC2)
+            new IndicatorListing {
+                Name = "Open-Close Average (OC2)",
+                Uiid = "OC2",
+                LegendTemplate = "OC2",
+                Endpoint = $"{baseUrl}/OC2/",
+                Category = "price-transform",
+                ChartType = "overlay",
+                Results = [
+                    new() {
+                        DisplayName = "OC2",
+                        TooltipTemplate = "OC2",
+                        DataName = "value",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    }
+                ]
+            },
+
+            // Quote transform: Open-High-Low Average (OHL3)
+            new IndicatorListing {
+                Name = "Open-High-Low Average (OHL3)",
+                Uiid = "OHL3",
+                LegendTemplate = "OHL3",
+                Endpoint = $"{baseUrl}/OHL3/",
+                Category = "price-transform",
+                ChartType = "overlay",
+                Results = [
+                    new() {
+                        DisplayName = "OHL3",
+                        TooltipTemplate = "OHL3",
+                        DataName = "value",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    }
+                ]
+            },
+
+            // Quote transform: Average Price (OHLC4)
+            new IndicatorListing {
+                Name = "Average Price (OHLC4)",
+                Uiid = "OHLC4",
+                LegendTemplate = "OHLC4",
+                Endpoint = $"{baseUrl}/OHLC4/",
+                Category = "price-transform",
+                ChartType = "overlay",
+                Results = [
+                    new() {
+                        DisplayName = "OHLC4",
+                        TooltipTemplate = "OHLC4",
+                        DataName = "value",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    }
+                ]
             }
         ];
 

--- a/server/WebApi/Services/Service.Metadata.cs
+++ b/server/WebApi/Services/Service.Metadata.cs
@@ -4012,6 +4012,265 @@ public static class Metadata
                         DefaultColor = ChartColors.StandardBlue
                     }
                 ]
+            },
+
+            // Gator Oscillator (derived from Williams Alligator)
+            new IndicatorListing {
+                Name = "Gator Oscillator",
+                Uiid = "GATOR",
+                LegendTemplate = "GATOR",
+                Endpoint = $"{baseUrl}/GATOR/",
+                Category = "price-trend",
+                ChartType = "oscillator",
+                Results = [
+                    new() {
+                        DisplayName = "Upper",
+                        TooltipTemplate = "Upper",
+                        DataName = "upper",
+                        DataType = "number",
+                        LineType = "bar",
+                        Stack = "gator",
+                        DefaultColor = ChartColors.StandardGreen
+                    },
+                    new() {
+                        DisplayName = "Lower",
+                        TooltipTemplate = "Lower",
+                        DataName = "lower",
+                        DataType = "number",
+                        LineType = "bar",
+                        Stack = "gator",
+                        DefaultColor = ChartColors.StandardRed
+                    }
+                ]
+            },
+
+            // Pivot Points (weekly window)
+            new IndicatorListing {
+                Name = "Pivot Points (week)",
+                Uiid = "PIVOT-POINTS",
+                LegendTemplate = "PIVOT POINTS(WEEK)",
+                Endpoint = $"{baseUrl}/PIVOT-POINTS/",
+                Category = "price-channel",
+                ChartType = "overlay",
+                Results = [
+                    new() {
+                        DisplayName = "R3",
+                        TooltipTemplate = "Resistance 3",
+                        DataName = "r3",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardRed
+                    },
+                    new() {
+                        DisplayName = "R2",
+                        TooltipTemplate = "Resistance 2",
+                        DataName = "r2",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardRed
+                    },
+                    new() {
+                        DisplayName = "R1",
+                        TooltipTemplate = "Resistance 1",
+                        DataName = "r1",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardRed
+                    },
+                    new() {
+                        DisplayName = "Pivot Point",
+                        TooltipTemplate = "Pivot Point",
+                        DataName = "pp",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    },
+                    new() {
+                        DisplayName = "S1",
+                        TooltipTemplate = "Support 1",
+                        DataName = "s1",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardGreen
+                    },
+                    new() {
+                        DisplayName = "S2",
+                        TooltipTemplate = "Support 2",
+                        DataName = "s2",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardGreen
+                    },
+                    new() {
+                        DisplayName = "S3",
+                        TooltipTemplate = "Support 3",
+                        DataName = "s3",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardGreen
+                    }
+                ]
+            },
+
+            // Pivots (Williams Fractal swing highs/lows with trend lines)
+            new IndicatorListing {
+                Name = "Pivots (Williams Fractal)",
+                Uiid = "PIVOTS",
+                LegendTemplate = "PIVOTS([P1],[P2],[P3])",
+                Endpoint = $"{baseUrl}/PIVOTS/",
+                Category = "price-pattern",
+                ChartType = "overlay",
+                Order = Order.Front,
+                Parameters =
+                [
+                    new() {
+                        DisplayName = "Left Span",
+                        ParamName = "leftSpan",
+                        DataType = "int",
+                        DefaultValue = 2,
+                        Minimum = 2,
+                        Maximum = 50
+                    },
+                    new() {
+                        DisplayName = "Right Span",
+                        ParamName = "rightSpan",
+                        DataType = "int",
+                        DefaultValue = 2,
+                        Minimum = 2,
+                        Maximum = 50
+                    },
+                    new() {
+                        DisplayName = "Max Trend Periods",
+                        ParamName = "maxTrendPeriods",
+                        DataType = "int",
+                        DefaultValue = 20,
+                        Minimum = 3,
+                        Maximum = 250
+                    }
+                ],
+                Results = [
+                    new() {
+                        DisplayName = "High Point",
+                        TooltipTemplate = "High Point",
+                        DataName = "highPoint",
+                        DataType = "number",
+                        LineType = "dots",
+                        LineWidth = 3,
+                        DefaultColor = ChartColors.StandardRed
+                    },
+                    new() {
+                        DisplayName = "Low Point",
+                        TooltipTemplate = "Low Point",
+                        DataName = "lowPoint",
+                        DataType = "number",
+                        LineType = "dots",
+                        LineWidth = 3,
+                        DefaultColor = ChartColors.StandardGreen
+                    },
+                    new() {
+                        DisplayName = "High Trend Line",
+                        TooltipTemplate = "High Trend Line",
+                        DataName = "highLine",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardRed
+                    },
+                    new() {
+                        DisplayName = "Low Trend Line",
+                        TooltipTemplate = "Low Trend Line",
+                        DataName = "lowLine",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardGreen
+                    }
+                ]
+            },
+
+            // Rolling Pivot Points
+            new IndicatorListing {
+                Name = "Rolling Pivot Points",
+                Uiid = "ROLLING-PIVOTS",
+                LegendTemplate = "ROLLING PIVOTS([P1],[P2])",
+                Endpoint = $"{baseUrl}/ROLLING-PIVOTS/",
+                Category = "price-channel",
+                ChartType = "overlay",
+                Parameters =
+                [
+                    new() {
+                        DisplayName = "Window Periods",
+                        ParamName = "windowPeriods",
+                        DataType = "int",
+                        DefaultValue = 11,
+                        Minimum = 1,
+                        Maximum = 250
+                    },
+                    new() {
+                        DisplayName = "Offset Periods",
+                        ParamName = "offsetPeriods",
+                        DataType = "int",
+                        DefaultValue = 9,
+                        Minimum = 0,
+                        Maximum = 250
+                    }
+                ],
+                Results = [
+                    new() {
+                        DisplayName = "R3",
+                        TooltipTemplate = "Resistance 3",
+                        DataName = "r3",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardRed
+                    },
+                    new() {
+                        DisplayName = "R2",
+                        TooltipTemplate = "Resistance 2",
+                        DataName = "r2",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardRed
+                    },
+                    new() {
+                        DisplayName = "R1",
+                        TooltipTemplate = "Resistance 1",
+                        DataName = "r1",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardRed
+                    },
+                    new() {
+                        DisplayName = "Pivot Point",
+                        TooltipTemplate = "Pivot Point",
+                        DataName = "pp",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    },
+                    new() {
+                        DisplayName = "S1",
+                        TooltipTemplate = "Support 1",
+                        DataName = "s1",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardGreen
+                    },
+                    new() {
+                        DisplayName = "S2",
+                        TooltipTemplate = "Support 2",
+                        DataName = "s2",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardGreen
+                    },
+                    new() {
+                        DisplayName = "S3",
+                        TooltipTemplate = "Support 3",
+                        DataName = "s3",
+                        DataType = "number",
+                        LineType = "dash",
+                        DefaultColor = ChartColors.StandardGreen
+                    }
+                ]
             }
         ];
 

--- a/server/WebApi/Services/Service.Metadata.cs
+++ b/server/WebApi/Services/Service.Metadata.cs
@@ -2819,7 +2819,7 @@ public static class Metadata
                         TooltipTemplate = "FORCE([P1])",
                         DataName = "forceIndex",
                         DataType = "number",
-                        LineType = "solid",
+                        LineType = "bar",
                         DefaultColor = ChartColors.StandardBlue
                     }
                 ]


### PR DESCRIPTION
## Summary

Adds new chartable indicators from #498, scoped to the ones that fit the client's existing rendering model. Each is a catalog entry a user can add on its own.

**Quote transforms** (single derived price line, `overlay`, `price-transform`):

| UIID | Name | Formula |
| --- | --- | --- |
| `HL2` | Median Price | (H + L) / 2 |
| `HLC3` | Typical Price | (H + L + C) / 3 |
| `OC2` | Open-Close Average | (O + C) / 2 |
| `OHL3` | Open-High-Low Average | (O + H + L) / 3 |
| `OHLC4` | Average Price | (O + H + L + C) / 4 |

**Gator & pivots** (from the follow-up evaluation of #498):

| UIID | Name | Chart | Notes |
| --- | --- | --- | --- |
| `GATOR` | Gator Oscillator | oscillator | Upper/lower histograms (lower is negative → draws down). Compute endpoint already existed; this adds the listing. |
| `PIVOT-POINTS` | Pivot Points (week) | overlay | PP + S1–S3 / R1–R3. Weekly window hardcoded (PeriodSize is an enum; param UI is numeric-only). |
| `PIVOTS` | Pivots (Williams Fractal) | overlay | Swing high/low markers + trend lines; three int spans, `endType` defaults to HighLow. |
| `ROLLING-PIVOTS` | Rolling Pivot Points | overlay | PP + S/R; `windowPeriods` / `offsetPeriods` int params, `pointType` defaults to Standard. |

## Why these and not the rest of #498

Three hard client constraints decided scope (confirmed in code, not assumed):
- **No candlestick rendering for indicators** — only the main price series draws candles. This rules out **Heikin-Ashi** and **Renko** without client-lib work.
- **X-axis is locked 1:1 to quote timestamps** (sliced by index). **Renko** bricks compress time and would misalign — a second, deeper blocker.
- **Numeric-only params** (no enum/select UI) — handled here by hardcoding `PeriodSize.Week` for Pivot Points and defaulting other enums.

**Correlation/R²** and **PRS** are technically feasible via BETA's "fetch SPY internally" pattern but fix the benchmark to SPY — left out as a product decision. **SMA Analysis** was judged low-value (MAD/MSE/MAPE don't share a y-scale).

## Changes

- **`server/WebApi/Endpoints.cs`** — new endpoints for PIVOT-POINTS, PIVOTS, ROLLING-PIVOTS, and the five quote transforms (Gator endpoint already existed), placed alphabetically.
- **`server/WebApi/Services/Service.Metadata.cs`** — catalog listings for all nine. Result `dataName`s verified against live API JSON; Camarilla-only `s4`/`r4` and non-numeric trend enums omitted.
- **`server/WebApi.Tests/...MainEndpointsTests.cs`** — endpoint tests (value-correctness for transforms; a 400 validation case for Pivots).
- **`client/src/app/data/backup-indicators.json`** — regenerated from the live API (offline fallback); catalog 83 → 92.

## Testing

- `dotnet test Charts.sln` → 41 passed
- `pnpm --filter client test` → 113 passed
- `dotnet format --verify-no-changes` clean; `prettier --check` clean
- Verified all new endpoints against a running API (Azurite + WebApi): correct counts, `{timestamp, …}` shapes, and that Gator's `lower` is negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)