### PR TITLE
fix: add Vary: Origin to cached CORS responses (cross-site cache poisoning)

### DIFF
--- a/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
+++ b/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
@@ -62,6 +62,34 @@ public class MainEndpointsTests
     }
 
     [Fact]
+    public async Task GetQuotes_SetsPublicCacheWithVaryOrigin()
+    {
+        // Arrange
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new Quote(DateTime.UtcNow, 100m, 102m, 99m, 101m, 1_000_000)]);
+
+        DefaultHttpContext httpContext = new();
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = httpContext
+        };
+
+        // Act
+        await _controller.GetQuotes();
+
+        // Assert — these responses are cached `public` AND carry a per-origin
+        // Access-Control-Allow-Origin, so they MUST advertise `Vary: Origin`.
+        // Without it a shared/browser cache serves one origin's cached copy (ACAO
+        // included) to a sibling same-site origin, breaking CORS for the whole
+        // max-age window (regression guard for #517).
+        Assert.Contains("Origin", httpContext.Response.Headers.Vary.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        string cacheControl = httpContext.Response.Headers.CacheControl.ToString();
+        Assert.Contains("public", cacheControl, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max-age", cacheControl, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void GetIndicatorCatalog_ReturnsOkResultWithMetadata()
     {
         // Arrange

--- a/server/WebApi/Endpoints.cs
+++ b/server/WebApi/Endpoints.cs
@@ -56,8 +56,22 @@ public class Main(IQuoteService quoteService, IOptions<CacheSettings> cacheSetti
     // Emit a shared-cache directive so browsers and CDN/edge caches (e.g.
     // Cloudflare in front of the doc site) can serve repeat requests without
     // reaching the origin. Mirrors the server-side output-cache lifetime.
+    //
+    // Vary: Origin is REQUIRED here. These responses carry a per-origin
+    // Access-Control-Allow-Origin (CORS). Without advertising the Origin vary, a
+    // shared HTTP cache keyed only by URL serves one origin's cached copy — ACAO
+    // included — to another origin, which then fails the browser CORS check. The
+    // doc site (dotnet.stockindicators.dev) and demo site
+    // (charts.stockindicators.dev) are sibling subdomains that share a browser
+    // cache partition, so a cross-site refresh would otherwise poison each
+    // other's cached quotes/indicators for the whole max-age window. The
+    // server-side OutputCache already varies by Origin; this mirrors that to the
+    // client. See facioquo/stock-charts#517.
     private void SetClientCache()
-        => Response.Headers.CacheControl = $"public, max-age={(int)cacheDuration.TotalSeconds}";
+    {
+        Response.Headers.CacheControl = $"public, max-age={(int)cacheDuration.TotalSeconds}";
+        Response.Headers.Append("Vary", "Origin");
+    }
 
     //////////////////////////////////////////
     // INDICATORS (sorted alphabetically)


### PR DESCRIPTION
## Problem

Refreshing one site then the other takes the **second** site's charts down for ~15 minutes, then they recover on their own. Root cause: cross-origin **browser-cache poisoning** from our cache headers.

`/quotes`, `/indicators`, and the indicator endpoints (with default params) are requested with **identical URLs** by both consumer sites, and each response is:

```
Cache-Control: public, max-age=900
Access-Control-Allow-Origin: <echoes the requesting origin>
Vary: Accept-Encoding          ← missing Origin
```

Because `dotnet.stockindicators.dev` (docs) and `charts.stockindicators.dev` (demo) are **sibling subdomains of the same registrable site**, they share one browser HTTP-cache partition. So:

1. Load **docs** → browser caches `…/quotes` with `Access-Control-Allow-Origin: dotnet…` baked in (cache key = URL; `Vary` ignores `Origin`).
2. Load **charts** → same URL → cache hit → browser reuses the docs copy → CORS check `dotnet ≠ charts` → **blocked → charts down**.
3. After `max-age=900` (15 min) the entry is stale → charts re-fetches → correct ACAO → recovers.

The **server-side `OutputCache` is fine** — it already keys per-origin via `SetVaryByHeader("Origin")` (isolated requests each get the right ACAO). The gap was that this vary was never advertised to the **client**.

## Fix

`SetClientCache()` now emits `Vary: Origin` alongside the `public, max-age` directive, so browsers and any shared/edge cache key per origin. One method change covers `/quotes`, `/indicators`, and every indicator endpoint.

```csharp
private void SetClientCache()
{
    Response.Headers.CacheControl = $"public, max-age={(int)cacheDuration.TotalSeconds}";
    Response.Headers.Append("Vary", "Origin");
}
```

## Tests

- Added `GetQuotes_SetsPublicCacheWithVaryOrigin` asserting `Vary: Origin` + `public`/`max-age` (regression guard).
- Full suite green: **47/47** (`dotnet test WebApi.Tests`).

## Scope / follow-ups

- **Addresses the P1 root cause in #517.** The remaining items there (single-instance API / no edge cache / no client retry / startup warming) stay open.
- ⚠️ **CDN caveat for #517's "front the API with Cloudflare" item:** Cloudflare does not vary its edge cache on arbitrary headers (only `Accept-Encoding`), so `Vary: Origin` alone won't make a CF-fronted API CORS-safe across these subdomains — the edge cache key would need `Origin` (Cache Rules / Worker) or CORS terminated at the edge. Worth designing in before that change.
- Related downstream: facioquo/stock-indicators-dotnet#2124 (simplify the docs chart integration) — still relevant for general client resilience, but lower priority now that the user-visible outage is fixed at the source.
