### PR TITLE
chore: Rename CLOUDFLARE_API_KEY secret to CLOUDFLARE_API_TOKEN

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -226,7 +226,7 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v4
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_KEY }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: "latest"
           command: >


### PR DESCRIPTION
The org secret was renamed `CLOUDFLARE_API_KEY` → `CLOUDFLARE_API_TOKEN` (rotated to a new value and aligned to the conventional name wrangler expects). The old secret no longer exists, so this deploy references it in vain — update to the new name so deploys keep working.

No behavior change; the token is the same scoped Pages/Workers API token, just correctly named.