### PR TITLE
feat: Split SMA analysis into per-metric chart listings

### DIFF
--- a/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
+++ b/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
@@ -552,6 +552,76 @@ public class MainEndpointsTests
     }
 
     [Fact]
+    public async Task GetSmaAnalysis_WithValidParameters_ReturnsOkResult()
+    {
+        // Arrange
+        List<Bar> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act
+        IActionResult result = await _controller.GetSmaAnalysis(14);
+
+        // Assert — the response carries all four metrics (sma, mad, mse, mape)
+        // for the visible window; the catalog splits them into per-metric
+        // listings client-side, so the endpoint itself stays whole.
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<SmaAnalysisResult> analysis = Assert.IsType<IEnumerable<SmaAnalysisResult>>(okResult.Value, exactMatch: false).ToList();
+        Assert.Equal(120, analysis.Count);
+        Assert.All(analysis, r => {
+            Assert.NotNull(r.Mad);
+            Assert.NotNull(r.Mse);
+            Assert.NotNull(r.Mape);
+        });
+    }
+
+    [Fact]
+    public async Task GetSmaAnalysis_WithInvalidParameters_ReturnsBadRequest()
+    {
+        // Arrange
+        List<Bar> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act — lookbackPeriods below the library minimum surfaces as 400 via
+        // the Get<T> helper, not a 500.
+        IActionResult result = await _controller.GetSmaAnalysis(0);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Theory]
+    [InlineData("SMA-MAD", "mad")]
+    [InlineData("SMA-MAPE", "mape")]
+    [InlineData("SMA-MSE", "mse")]
+    public void SmaAnalysisListings_ExposeOneMetricEach(string uiid, string dataName)
+    {
+        // The metrics have incompatible units (dollars, fraction, dollars²), so
+        // each listing must chart exactly one metric on its own pane (#475). A
+        // regression that recombines them would revive the unreadable shared
+        // y-axis this split exists to prevent.
+        Models.IndicatorListing listing = Metadata
+            .IndicatorListing("https://localhost")
+            .Single(l => l.Uiid == uiid);
+
+        Assert.Equal("oscillator", listing.ChartType);
+        Assert.EndsWith("/SMA-ANALYSIS/", listing.Endpoint, StringComparison.Ordinal);
+        Models.IndicatorResultConfig result = Assert.Single(listing.Results);
+        Assert.Equal(dataName, result.DataName);
+    }
+
+    [Fact]
     public void PivotPointsListing_MarksAllLevelsSegmented()
     {
         // monthly Pivot Points are piecewise-constant level lines: the client

--- a/server/WebApi/Endpoints.cs
+++ b/server/WebApi/Endpoints.cs
@@ -337,6 +337,14 @@ public class Main(IQuoteService quoteService, IOptions<CacheSettings> cacheSetti
     public Task<IActionResult> GetSma(int lookbackPeriods)
         => Get(quotes => quotes.ToSma(lookbackPeriods));
 
+    // One endpoint backs the SMA-MAD / SMA-MSE / SMA-MAPE catalog entries. The
+    // metrics carry incompatible units (dollars, dollars², fraction), so each
+    // listing charts a single metric on its own pane instead of sharing a
+    // y-axis. See #475.
+    [HttpGet("SMA-ANALYSIS")]
+    public Task<IActionResult> GetSmaAnalysis(int lookbackPeriods)
+        => Get(quotes => quotes.ToSmaAnalysis(lookbackPeriods));
+
     [HttpGet("SMI")]
     public Task<IActionResult> GetSmi(int lookbackPeriods, int firstSmoothPeriods, int secondSmoothPeriods, int signalPeriods)
         => Get(quotes => quotes.ToSmi(lookbackPeriods, firstSmoothPeriods, secondSmoothPeriods, signalPeriods));

--- a/server/WebApi/Services/Service.Metadata.cs
+++ b/server/WebApi/Services/Service.Metadata.cs
@@ -3043,6 +3043,101 @@ public static class Metadata
                 ]
             },
 
+            // SMA Analysis — one listing per error metric. MAD (dollars),
+            // MSE (dollars²), and MAPE (fraction) have incompatible units, so
+            // charting them together flattens the smaller series into
+            // unreadable lines (#475). All three share the SMA-ANALYSIS
+            // endpoint and select a single metric from its response.
+            new IndicatorListing {
+                Name = "SMA Error Analysis (MAD)",
+                Uiid = "SMA-MAD",
+                LegendTemplate = "SMA-MAD([P1])",
+                Endpoint = $"{baseUrl}/SMA-ANALYSIS/",
+                Category = "price-characteristic",
+                ChartType = "oscillator",
+                Parameters =
+                [
+                    new() {
+                        DisplayName = "Lookback Periods",
+                        ParamName = "lookbackPeriods",
+                        DataType = "int",
+                        DefaultValue = 14,
+                        Minimum = 2,
+                        Maximum = 250
+                    }
+                ],
+                Results = [
+                    new() {
+                        DisplayName = "Mean Absolute Deviation",
+                        TooltipTemplate = "SMA-MAD([P1])",
+                        DataName = "mad",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    }
+                ]
+            },
+
+            new IndicatorListing {
+                Name = "SMA Error Analysis (MAPE)",
+                Uiid = "SMA-MAPE",
+                LegendTemplate = "SMA-MAPE([P1])",
+                Endpoint = $"{baseUrl}/SMA-ANALYSIS/",
+                Category = "price-characteristic",
+                ChartType = "oscillator",
+                Parameters =
+                [
+                    new() {
+                        DisplayName = "Lookback Periods",
+                        ParamName = "lookbackPeriods",
+                        DataType = "int",
+                        DefaultValue = 14,
+                        Minimum = 2,
+                        Maximum = 250
+                    }
+                ],
+                Results = [
+                    new() {
+                        DisplayName = "Mean Absolute Percentage Error",
+                        TooltipTemplate = "SMA-MAPE([P1])",
+                        DataName = "mape",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    }
+                ]
+            },
+
+            new IndicatorListing {
+                Name = "SMA Error Analysis (MSE)",
+                Uiid = "SMA-MSE",
+                LegendTemplate = "SMA-MSE([P1])",
+                Endpoint = $"{baseUrl}/SMA-ANALYSIS/",
+                Category = "price-characteristic",
+                ChartType = "oscillator",
+                Parameters =
+                [
+                    new() {
+                        DisplayName = "Lookback Periods",
+                        ParamName = "lookbackPeriods",
+                        DataType = "int",
+                        DefaultValue = 14,
+                        Minimum = 2,
+                        Maximum = 250
+                    }
+                ],
+                Results = [
+                    new() {
+                        DisplayName = "Mean Squared Error",
+                        TooltipTemplate = "SMA-MSE([P1])",
+                        DataName = "mse",
+                        DataType = "number",
+                        LineType = "solid",
+                        DefaultColor = ChartColors.StandardBlue
+                    }
+                ]
+            },
+
             // Slope
             new IndicatorListing {
                 Name = "Slope",


### PR DESCRIPTION
Re-exposes the SMA-ANALYSIS endpoint that was removed pending a
multi-chart design. MAD, MAPE, and MSE carry incompatible units
(dollars, fraction, dollars²), so each gets its own oscillator listing
selecting a single metric from the shared endpoint — no more shared
y-axis where MSE flattens the others into unreadable lines.

Closes #475

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>