### PR TITLE
feat: Add candle line type for OHLC indicator results

### DIFF
--- a/libs/indy-charts/charts/chart-manager.spec.ts
+++ b/libs/indy-charts/charts/chart-manager.spec.ts
@@ -87,6 +87,7 @@ function createMockOverlay(): Partial<OverlayChart> {
     }),
     addIndicatorDatasets: vi.fn(),
     removeIndicatorDatasets: vi.fn(),
+    setPriceVisibility: vi.fn(),
     updateLegends: vi.fn(),
     updateTheme: vi.fn(),
     buildFullDatasets: vi.fn().mockImplementation((quotes: Bar[]) => {
@@ -427,7 +428,7 @@ describe("ChartManager", () => {
       // carry { x, o, h, l, c } read from the row's fixed OHLC fields (not a
       // single dataName value), stay 1:1 with rows plus trailing padding, and
       // skip the per-point color arrays used by pattern/histogram series.
-      const listing = makeOscillatorListing({
+      const listing = makeOverlayListing({
         uiid: "HEIKIN-ASHI",
         category: "price-transform",
         chartConfig: null,
@@ -567,6 +568,67 @@ describe("ChartManager", () => {
       const overlay = mgr.overlayChart as unknown as ReturnType<typeof createMockOverlay>;
       expect(overlay.addIndicatorDatasets).toHaveBeenCalled();
       expect(overlay.updateLegends).toHaveBeenCalled();
+    });
+
+    it("hides the price candles while a candle overlay is displayed and restores on removal", () => {
+      // Candle-rendered overlays (e.g. Heikin-Ashi) REPLACE the raw price
+      // candles: both sit at nearly the same prices, so drawing them together
+      // occludes each other. Volume is untouched.
+      const ctx = {} as CanvasRenderingContext2D;
+      mgr.initializeOverlay(ctx, makeQuotes(50), 25);
+      const overlay = mgr.overlayChart as unknown as ReturnType<typeof createMockOverlay>;
+
+      const listing = makeOverlayListing({
+        uiid: "HEIKIN-ASHI",
+        category: "price-transform",
+        parameters: [],
+        results: [
+          {
+            dataName: "close",
+            displayName: "Heikin-Ashi",
+            tooltipTemplate: "HA",
+            defaultColor: "#4169E1",
+            lineType: "candle",
+            lineWidth: 2,
+            dataType: "number",
+            stack: "",
+            order: 1
+          }
+        ]
+      });
+      const selection = makeSelection(listing, "ha-vis");
+      const quotes = makeQuotes(50);
+      mgr.processSelectionData(
+        selection,
+        listing,
+        quotes.map(q => ({
+          timestamp: new Date(q.timestamp).toISOString(),
+          open: q.open,
+          high: q.high,
+          low: q.low,
+          close: q.close
+        }))
+      );
+
+      mgr.displaySelection(selection, listing);
+      expect(overlay.setPriceVisibility).toHaveBeenLastCalledWith(false);
+
+      mgr.removeSelection("ha-vis");
+      expect(overlay.setPriceVisibility).toHaveBeenLastCalledWith(true);
+    });
+
+    it("keeps the price candles visible for ordinary line overlays", () => {
+      const ctx = {} as CanvasRenderingContext2D;
+      mgr.initializeOverlay(ctx, makeQuotes(50), 25);
+      const overlay = mgr.overlayChart as unknown as ReturnType<typeof createMockOverlay>;
+
+      const listing = makeOverlayListing();
+      const selection = makeSelection(listing, "sma-vis");
+      mgr.processSelectionData(selection, listing, makeIndicatorData(makeQuotes(50)));
+
+      mgr.displaySelection(selection, listing);
+
+      expect(overlay.setPriceVisibility).toHaveBeenLastCalledWith(true);
     });
 
     it("does not register the same ucid twice", () => {

--- a/libs/indy-charts/charts/chart-manager.spec.ts
+++ b/libs/indy-charts/charts/chart-manager.spec.ts
@@ -422,6 +422,62 @@ describe("ChartManager", () => {
       expect(selection.results[0].dataset.data.length).toBeGreaterThan(0);
     });
 
+    it("builds OHLC candle datasets from row open/high/low/close fields", () => {
+      // Heikin-Ashi-style listing: one result rendered as candles. Points must
+      // carry { x, o, h, l, c } read from the row's fixed OHLC fields (not a
+      // single dataName value), stay 1:1 with rows plus trailing padding, and
+      // skip the per-point color arrays used by pattern/histogram series.
+      const listing = makeOscillatorListing({
+        uiid: "HEIKIN-ASHI",
+        category: "price-transform",
+        chartConfig: null,
+        parameters: [],
+        results: [
+          {
+            dataName: "close",
+            displayName: "Heikin-Ashi",
+            tooltipTemplate: "HA",
+            defaultColor: "#4169E1",
+            lineType: "candle",
+            lineWidth: 2,
+            dataType: "number",
+            stack: "",
+            order: 1
+          }
+        ]
+      });
+      const selection = makeSelection(listing, "ha-1");
+      const quotes = makeQuotes(5);
+      const data: IndicatorDataRow[] = quotes.map(q => ({
+        timestamp: new Date(q.timestamp).toISOString(),
+        open: q.open,
+        high: q.high,
+        low: q.low,
+        close: q.close
+      }));
+
+      mgr.processSelectionData(selection, listing, data);
+
+      const dataset = selection.results[0].dataset;
+      expect(dataset.type).toBe("candlestick");
+      // 5 rows + EXTRA_BARS (6) trailing padding
+      expect(dataset.data).toHaveLength(11);
+      expect(dataset.data[0]).toEqual({
+        x: new Date(quotes[0].timestamp).valueOf(),
+        o: quotes[0].open,
+        h: quotes[0].high,
+        l: quotes[0].low,
+        c: quotes[0].close
+      });
+      // trailing padding is invisible all-NaN OHLC
+      const padded = dataset.data[10] as { o: number; c: number };
+      expect(padded.o).toBeNaN();
+      expect(padded.c).toBeNaN();
+      // candle coloring comes from themed element defaults, not point arrays
+      expect(dataset.pointBackgroundColor).toBeUndefined();
+      expect(dataset.backgroundColor).toBeUndefined();
+    });
+
     it("colors histogram bars per the <dataName>IsExpanding flags", () => {
       // Gator-style oscillator: two bar histograms whose color encodes whether
       // each bar is expanding (green) or contracting (red), per the standard

--- a/libs/indy-charts/charts/chart-manager.ts
+++ b/libs/indy-charts/charts/chart-manager.ts
@@ -274,8 +274,7 @@ export class ChartManager {
   private syncPriceCandleVisibility(): void {
     if (!this._overlayChart) return;
     const hasCandleOverlay = this._selections.some(
-      s =>
-        s.chartType === CHART_TYPES.OVERLAY && s.results.some(r => r.lineType === "candle")
+      s => s.chartType === CHART_TYPES.OVERLAY && s.results.some(r => r.lineType === "candle")
     );
     this._overlayChart.setPriceVisibility(!hasCandleOverlay);
   }

--- a/libs/indy-charts/charts/chart-manager.ts
+++ b/libs/indy-charts/charts/chart-manager.ts
@@ -13,7 +13,12 @@ import {
 } from "../config/types";
 
 import { baseDataset } from "../config/datasets";
-import { buildDataPoints, addExtraBars } from "../data/transformers";
+import {
+  buildDataPoints,
+  buildFinancialDataPoints,
+  addExtraBars,
+  addExtraFinancialBars
+} from "../data/transformers";
 import { OverlayChart } from "./overlay-chart";
 import { OscillatorChart } from "./oscillator-chart";
 
@@ -140,6 +145,19 @@ export class ChartManager {
       if (!resultConfig) return;
 
       const dataset = baseDataset(result, resultConfig);
+
+      // Candle series carry `{ x, o, h, l, c }` points read from the row's
+      // OHLC fields rather than a single `dataName` value, and take their
+      // up/down coloring from the themed candlestick element defaults — the
+      // per-point color machinery below does not apply.
+      if (result.lineType === "candle") {
+        const candlePoints = buildFinancialDataPoints(data, result);
+        addExtraFinancialBars(candlePoints, this.extraBars);
+        dataset.data = candlePoints;
+        result.dataset = dataset;
+        return;
+      }
+
       const { dataPoints, pointColor, pointRotation, hasConditionalColor } = buildDataPoints(
         data,
         result,

--- a/libs/indy-charts/charts/chart-manager.ts
+++ b/libs/indy-charts/charts/chart-manager.ts
@@ -260,6 +260,24 @@ export class ChartManager {
 
     this._overlayChart.addIndicatorDatasets(selection.results);
     this._overlayChart.updateLegends(this._selections);
+    this.syncPriceCandleVisibility();
+  }
+
+  /**
+   * Hide the raw price candles while any candle-rendered overlay (e.g.
+   * Heikin-Ashi) is displayed, and restore them when the last one is removed.
+   * The transform *replaces* the price bars — both series sit at nearly the
+   * same prices, so drawing them together occludes each other. Volume is
+   * unaffected. Runs after every overlay add/remove, including the re-attach
+   * pass in `initializeOverlay`, so the state survives overlay re-creation.
+   */
+  private syncPriceCandleVisibility(): void {
+    if (!this._overlayChart) return;
+    const hasCandleOverlay = this._selections.some(
+      s =>
+        s.chartType === CHART_TYPES.OVERLAY && s.results.some(r => r.lineType === "candle")
+    );
+    this._overlayChart.setPriceVisibility(!hasCandleOverlay);
   }
 
   /**
@@ -345,6 +363,7 @@ export class ChartManager {
       if (this._overlayChart) {
         this._overlayChart.removeIndicatorDatasets(selection.results);
         this._overlayChart.updateLegends(this._selections);
+        this.syncPriceCandleVisibility();
         this._overlayChart.chart?.update();
       }
     } else {

--- a/libs/indy-charts/charts/overlay-chart.ts
+++ b/libs/indy-charts/charts/overlay-chart.ts
@@ -123,6 +123,22 @@ export class OverlayChart {
     this._chart.update("none");
   }
 
+  /**
+   * Show or hide the main price candlestick dataset (index 0 — the same
+   * invariant `applySlicedData` relies on). Used when a candle-rendered
+   * overlay indicator (e.g. Heikin-Ashi) replaces the raw price candles:
+   * the transform sits at nearly the same prices, so drawing both just
+   * occludes the two series. Hidden datasets are excluded from y-scale
+   * bounds and tooltips, so the replacement series drives both.
+   */
+  setPriceVisibility(visible: boolean): void {
+    if (!this._chart) return;
+    const price = this._chart.data.datasets[0];
+    if (!price || price.type !== "candlestick") return;
+    price.hidden = !visible;
+    this._chart.update("none");
+  }
+
   updateLegends(overlaySelections: IndicatorSelection[]): void {
     if (!this._chart) return;
     if (!this._chart.scales["x"] || !this._chart.scales["y"]) return;

--- a/libs/indy-charts/config/datasets.spec.ts
+++ b/libs/indy-charts/config/datasets.spec.ts
@@ -50,6 +50,19 @@ describe("baseDataset", () => {
     expect(ds.stack).toBe("macd-hist");
   });
 
+  it("returns a candlestick dataset for lineType=candle without per-result color", () => {
+    const ds = baseDataset(
+      makeResult({ lineType: "candle", dataName: "close" }),
+      makeResultConfig({ lineType: "candle", dataName: "close" })
+    );
+    expect(ds.type).toBe("candlestick");
+    expect(ds.data).toEqual([]);
+    // up/down coloring comes from the themed candlestick element defaults;
+    // a static per-result color would override the up/down split.
+    expect(ds.borderColor).toBeUndefined();
+    expect(ds.backgroundColor).toBeUndefined();
+  });
+
   it("throws on an unsupported lineType", () => {
     expect(() =>
       baseDataset(makeResult({ lineType: "spline" }), makeResultConfig({ lineType: "spline" }))

--- a/libs/indy-charts/config/datasets.ts
+++ b/libs/indy-charts/config/datasets.ts
@@ -102,6 +102,21 @@ export function baseDataset(r: IndicatorResult, c: IndicatorResultConfig): Indic
       return ptDataset;
     }
 
+    case "candle": {
+      // OHLC series (e.g. Heikin-Ashi). Data is `{ x, o, h, l, c }` points
+      // built by `buildFinancialDataPoints`, not `{ x, y }`. Up/down/unchanged
+      // colors come from the globally themed candlestick element defaults
+      // (`applyFinancialElementTheme`), so no per-result color is applied.
+      const candleDataset: IndicatorDataset = {
+        label: r.label,
+        type: "candlestick",
+        data: [],
+        yAxisID: "y",
+        order: r.order
+      };
+      return candleDataset;
+    }
+
     case "none": {
       // hide instead of exclude 'none' lines,
       // otherwise, it breaks line offset fill

--- a/libs/indy-charts/config/types.ts
+++ b/libs/indy-charts/config/types.ts
@@ -1,14 +1,24 @@
 import { type ChartDataset, type ScatterDataPoint } from "chart.js";
 
+import { type FinancialDataPoint } from "../types/financial.types";
+
 // CHARTS
 
 /**
- * Indicator datasets are line or bar series of `{ x, y }` points. Pinning the
- * data shape lets callers (e.g. createThresholdDataset) read `dataset.data` as
- * `ScatterDataPoint[]` without casts, and keeps the shape consistent with
- * `buildDataPoints` / `addExtraBars` output.
+ * A single indicator data point: `{ x, y }` for line/bar series, or
+ * `{ x, o, h, l, c }` for candle series (lineType "candle"). Both carry a
+ * numeric `x` epoch, which is all shared consumers (thresholds, extra-bar
+ * padding, window slicing) rely on.
  */
-export type IndicatorDataset = ChartDataset<"line" | "bar", ScatterDataPoint[]>;
+export type IndicatorPoint = ScatterDataPoint | FinancialDataPoint;
+
+/**
+ * Indicator datasets are line, bar, or candlestick series. Pinning the data
+ * shape lets callers (e.g. createThresholdDataset) read `dataset.data` as
+ * `IndicatorPoint[]` without casts, and keeps the shape consistent with
+ * `buildDataPoints` / `buildFinancialDataPoints` / `addExtraBars` output.
+ */
+export type IndicatorDataset = ChartDataset<"line" | "bar" | "candlestick", IndicatorPoint[]>;
 
 /**
  * Candlestick-pattern indicators set per-point style arrays

--- a/libs/indy-charts/data/transformers.spec.ts
+++ b/libs/indy-charts/data/transformers.spec.ts
@@ -3,7 +3,9 @@ import { type ScatterDataPoint } from "chart.js";
 import {
   processQuoteData,
   buildDataPoints,
+  buildFinancialDataPoints,
   addExtraBars,
+  addExtraFinancialBars,
   getCandlePointConfiguration
 } from "./transformers";
 import type { IndicatorDataRow, IndicatorListing, IndicatorResult, Bar } from "../config/types";
@@ -688,5 +690,93 @@ describe("getCandlePointConfiguration", () => {
     const config = getCandlePointConfiguration(100, q);
 
     expect(config.yValue).toBe(0.99 * 197);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFinancialDataPoints
+// ---------------------------------------------------------------------------
+
+describe("buildFinancialDataPoints", () => {
+  const result = makeResult({ dataName: "close", lineType: "candle" });
+
+  it("maps rows to { x, o, h, l, c } points from fixed OHLC fields", () => {
+    const rows: IndicatorDataRow[] = [
+      { timestamp: "2024-01-02", open: 101, high: 104, low: 99, close: 103 }
+    ];
+
+    const points = buildFinancialDataPoints(rows, result);
+
+    expect(points).toEqual([
+      { x: new Date("2024-01-02").valueOf(), o: 101, h: 104, l: 99, c: 103 }
+    ]);
+  });
+
+  it("keeps 1:1 row alignment, mapping missing OHLC fields to NaN", () => {
+    // Window slicing is index-based, so warmup rows must become NaN
+    // placeholders (drawn as gaps) rather than being dropped.
+    const rows: IndicatorDataRow[] = [
+      { timestamp: "2024-01-02" },
+      { timestamp: "2024-01-03", open: 101, high: 104, low: 99, close: 103 }
+    ];
+
+    const points = buildFinancialDataPoints(rows, result);
+
+    expect(points).toHaveLength(2);
+    expect(points[0].o).toBeNaN();
+    expect(points[0].h).toBeNaN();
+    expect(points[0].l).toBeNaN();
+    expect(points[0].c).toBeNaN();
+    expect(points[1].c).toBe(103);
+  });
+
+  it("throws when a row is missing its timestamp", () => {
+    const rows: IndicatorDataRow[] = [{ open: 101, high: 104, low: 99, close: 103 }];
+
+    expect(() => buildFinancialDataPoints(rows, result)).toThrow(/missing 'timestamp'/);
+  });
+
+  it("throws when a row has an unparseable timestamp", () => {
+    const rows: IndicatorDataRow[] = [
+      { timestamp: "not-a-date", open: 101, high: 104, low: 99, close: 103 }
+    ];
+
+    expect(() => buildFinancialDataPoints(rows, result)).toThrow(/invalid timestamp/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addExtraFinancialBars
+// ---------------------------------------------------------------------------
+
+describe("addExtraFinancialBars", () => {
+  it("pads with all-NaN OHLC points on future business days", () => {
+    const points = [{ x: new Date("2024-06-14T00:00:00Z").valueOf(), o: 1, h: 2, l: 0, c: 1 }]; // Friday
+
+    addExtraFinancialBars(points, 2);
+
+    expect(points).toHaveLength(3);
+    // Friday → Monday → Tuesday (weekend skipped)
+    expect(points[1].x).toBe(new Date("2024-06-17T00:00:00Z").valueOf());
+    expect(points[2].x).toBe(new Date("2024-06-18T00:00:00Z").valueOf());
+    [points[1], points[2]].forEach(p => {
+      expect(p.o).toBeNaN();
+      expect(p.h).toBeNaN();
+      expect(p.l).toBeNaN();
+      expect(p.c).toBeNaN();
+    });
+  });
+
+  it("produces the same padded x values as addExtraBars for shared axes", () => {
+    // Candle and line datasets on the same chart must stay x-aligned, so the
+    // two padding paths must walk identical business-day cadences.
+    const start = new Date("2024-06-13T00:00:00Z").valueOf();
+    const linePoints: ScatterDataPoint[] = [{ x: start, y: 5 }];
+    const candlePoints = [{ x: start, o: 1, h: 2, l: 0, c: 1 }];
+
+    addExtraBars(linePoints, 4);
+    addExtraFinancialBars(candlePoints, 4);
+
+    expect(candlePoints.map(p => p.x)).toEqual(linePoints.map(p => p.x));
   });
 });

--- a/libs/indy-charts/data/transformers.ts
+++ b/libs/indy-charts/data/transformers.ts
@@ -172,7 +172,54 @@ function resolveExpandingColor(row: IndicatorDataRow, dataName: string): string 
   return flag ? COLORS.GREEN : COLORS.RED;
 }
 
-export function addExtraBars(dataPoints: ScatterDataPoint[], extraBars: number): void {
+/**
+ * Build OHLC data points for a candle-rendered indicator result (lineType
+ * "candle", e.g. Heikin-Ashi). Unlike {@link buildDataPoints}, which extracts a
+ * single `y` value per row by `dataName`, this reads the fixed
+ * `open`/`high`/`low`/`close` fields the API emits for OHLC series. Rows keep
+ * 1:1 index alignment with quotes — non-numeric fields become NaN (drawn as a
+ * gap) rather than being dropped — because window slicing is index-based.
+ */
+export function buildFinancialDataPoints(
+  data: IndicatorDataRow[],
+  result: IndicatorResult
+): FinancialDataPoint[] {
+  return data.map(row => {
+    if (row.timestamp == null) {
+      throw new Error(`Indicator row missing 'timestamp' field for "${result.dataName}"`);
+    }
+    const x = new Date(row.timestamp).valueOf();
+    if (!Number.isFinite(x)) {
+      throw new Error(
+        `Indicator row has invalid timestamp for "${result.dataName}": ${String(row.timestamp)}`
+      );
+    }
+    return {
+      x,
+      o: numberOrNaN(row.open),
+      h: numberOrNaN(row.high),
+      l: numberOrNaN(row.low),
+      c: numberOrNaN(row.close)
+    };
+  });
+}
+
+function numberOrNaN(value: unknown): number {
+  return typeof value === "number" ? value : NaN;
+}
+
+/**
+ * Compute trailing x-axis timestamps continuing past the last data point.
+ * Advances one business day per bar, skipping Saturday (6) and Sunday (0), so
+ * extra bars align with expected trading sessions on daily charts. UTC methods
+ * keep the padded dates deterministic across client timezones — local-time
+ * arithmetic would shift the cadence near midnight UTC and let overlay vs
+ * oscillator x-axes drift apart on browsers in different zones.
+ */
+function extraBarTimestamps(
+  dataPoints: ReadonlyArray<{ x: number | null }>,
+  extraBars: number
+): number[] {
   const maxTime =
     dataPoints.length > 0
       ? Math.max(
@@ -186,17 +233,30 @@ export function addExtraBars(dataPoints: ScatterDataPoint[], extraBars: number):
   // Fall back to today when dataPoints is empty or every timestamp was invalid.
   const baseDate = maxTime > 0 ? new Date(maxTime) : new Date();
 
+  const timestamps: number[] = [];
   for (let i = 0; i < extraBars; i++) {
-    // Advance to the next business day, skipping Saturday (6) and Sunday (0),
-    // so extra bars align with expected trading sessions on daily charts.
-    // UTC methods keep the padded dates deterministic across client timezones —
-    // local-time arithmetic would shift the cadence near midnight UTC and let
-    // overlay vs oscillator x-axes drift apart on browsers in different zones.
     do {
       baseDate.setUTCDate(baseDate.getUTCDate() + 1);
     } while (baseDate.getUTCDay() === 0 || baseDate.getUTCDay() === 6);
-    dataPoints.push({ x: baseDate.valueOf(), y: NaN });
+    timestamps.push(baseDate.valueOf());
   }
+  return timestamps;
+}
+
+export function addExtraBars(dataPoints: ScatterDataPoint[], extraBars: number): void {
+  extraBarTimestamps(dataPoints, extraBars).forEach(x => dataPoints.push({ x, y: NaN }));
+}
+
+/**
+ * Candle-series counterpart of {@link addExtraBars}: pads with all-NaN OHLC
+ * points so candle datasets stay x-axis aligned with line/bar datasets that
+ * carry the same trailing padding. NaN geometry draws nothing and fails
+ * hit-testing, so the padding is invisible and untooltipped.
+ */
+export function addExtraFinancialBars(dataPoints: FinancialDataPoint[], extraBars: number): void {
+  extraBarTimestamps(dataPoints, extraBars).forEach(x =>
+    dataPoints.push({ x, o: NaN, h: NaN, l: NaN, c: NaN })
+  );
 }
 
 export function getCandlePointConfiguration(


### PR DESCRIPTION
New lineType "candle" renders an indicator result as a candlestick
series built from the row's open/high/low/close fields, instead of a
single-value line/bar. Points stay 1:1 index-aligned with quotes (NaN
placeholders for warmup rows) so index-based window slicing keeps
working, and trailing extra-bar padding uses all-NaN OHLC points that
walk the same business-day cadence as line padding, keeping shared
x-axes aligned. Up/down colors come from the globally themed
candlestick element defaults.

Groundwork for the Heikin-Ashi chart (#498).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>