### PR TITLE
feat: Add Heikin-Ashi chart endpoint and catalog entry

### DIFF
--- a/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
+++ b/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
@@ -582,16 +582,17 @@ public class MainEndpointsTests
     }
 
     [Fact]
-    public void HeikinAshiListing_RendersAsCandlePane()
+    public void HeikinAshiListing_RendersAsCandleOverlay()
     {
-        // The candle line type reads open/high/low/close from each row; the
-        // oscillator chart type gives the transform its own pane instead of
-        // occluding the raw price candles (#498).
+        // The candle line type reads open/high/low/close from each row. The
+        // overlay chart type puts the transform on the price chart, where the
+        // client hides the raw price candles while it is displayed — the
+        // transform replaces them rather than coexisting (#498).
         Models.IndicatorListing listing = Metadata
             .IndicatorListing("https://localhost")
             .Single(l => l.Uiid == "HEIKIN-ASHI");
 
-        Assert.Equal("oscillator", listing.ChartType);
+        Assert.Equal("overlay", listing.ChartType);
         Models.IndicatorResultConfig result = Assert.Single(listing.Results);
         Assert.Equal("candle", result.LineType);
         Assert.Equal("close", result.DataName);

--- a/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
+++ b/server/WebApi.Tests/Endpoints/MainEndpointsTests.cs
@@ -552,6 +552,52 @@ public class MainEndpointsTests
     }
 
     [Fact]
+    public async Task GetHeikinAshi_WithValidQuotes_ReturnsOkResult()
+    {
+        // Arrange
+        List<Bar> sampleQuotes = GenerateSampleQuotes(150);
+        _quoteServiceMock
+            .Setup(q => q.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sampleQuotes);
+
+        _controller.ControllerContext = new ControllerContext {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Act
+        IActionResult result = await _controller.GetHeikinAshi();
+
+        // Assert — rows stay 1:1 with the visible quote window (the client's
+        // index-based window slicing depends on it), and every row carries the
+        // full OHLC set the candle renderer reads.
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        List<HeikinAshiResult> ha = Assert.IsType<IEnumerable<HeikinAshiResult>>(okResult.Value, exactMatch: false).ToList();
+        Assert.Equal(120, ha.Count);
+        Assert.All(ha, r => {
+            Assert.NotEqual(default, r.Open);
+            Assert.NotEqual(default, r.High);
+            Assert.NotEqual(default, r.Low);
+            Assert.NotEqual(default, r.Close);
+        });
+    }
+
+    [Fact]
+    public void HeikinAshiListing_RendersAsCandlePane()
+    {
+        // The candle line type reads open/high/low/close from each row; the
+        // oscillator chart type gives the transform its own pane instead of
+        // occluding the raw price candles (#498).
+        Models.IndicatorListing listing = Metadata
+            .IndicatorListing("https://localhost")
+            .Single(l => l.Uiid == "HEIKIN-ASHI");
+
+        Assert.Equal("oscillator", listing.ChartType);
+        Models.IndicatorResultConfig result = Assert.Single(listing.Results);
+        Assert.Equal("candle", result.LineType);
+        Assert.Equal("close", result.DataName);
+    }
+
+    [Fact]
     public async Task GetSmaAnalysis_WithValidParameters_ReturnsOkResult()
     {
         // Arrange

--- a/server/WebApi/Endpoints.cs
+++ b/server/WebApi/Endpoints.cs
@@ -221,6 +221,10 @@ public class Main(IQuoteService quoteService, IOptions<CacheSettings> cacheSetti
     public Task<IActionResult> GetGator()
         => Get(quotes => quotes.ToGator());
 
+    [HttpGet("HEIKIN-ASHI")]
+    public Task<IActionResult> GetHeikinAshi()
+        => Get(quotes => quotes.ToHeikinAshi());
+
     [HttpGet("HL2")]
     public Task<IActionResult> GetHl2()
         => Get(quotes => quotes.Use(CandlePart.HL2));

--- a/server/WebApi/Services/Service.Metadata.cs
+++ b/server/WebApi/Services/Service.Metadata.cs
@@ -1558,6 +1558,33 @@ public static class Metadata
                 ]
             },
 
+            // Heikin-Ashi
+            new IndicatorListing {
+                Name = "Heikin-Ashi",
+                Uiid = "HEIKIN-ASHI",
+                LegendTemplate = "HEIKIN-ASHI",
+                Endpoint = $"{baseUrl}/HEIKIN-ASHI/",
+                Category = "price-transform",
+                // Rendered in its own pane rather than as a price overlay:
+                // Heikin-Ashi candles sit at nearly the same prices as the raw
+                // candles, so overlaying the two just occludes both. The
+                // side-by-side pane matches how charting platforms present the
+                // transform for comparison.
+                ChartType = "oscillator",
+                Results = [
+                    new() {
+                        DisplayName = "Heikin-Ashi",
+                        TooltipTemplate = "HEIKIN-ASHI",
+                        // LineType "candle" reads open/high/low/close from each
+                        // row; dataName anchors tooltips and result identity.
+                        DataName = "close",
+                        DataType = "number",
+                        LineType = "candle",
+                        DefaultColor = ChartColors.StandardBlue
+                    }
+                ]
+            },
+
             // Hilbert Transform Instantaneous Trendline
             new IndicatorListing {
                 Name = "Hilbert Transform Instantaneous Trendline",

--- a/server/WebApi/Services/Service.Metadata.cs
+++ b/server/WebApi/Services/Service.Metadata.cs
@@ -1565,12 +1565,12 @@ public static class Metadata
                 LegendTemplate = "HEIKIN-ASHI",
                 Endpoint = $"{baseUrl}/HEIKIN-ASHI/",
                 Category = "price-transform",
-                // Rendered in its own pane rather than as a price overlay:
-                // Heikin-Ashi candles sit at nearly the same prices as the raw
-                // candles, so overlaying the two just occludes both. The
-                // side-by-side pane matches how charting platforms present the
-                // transform for comparison.
-                ChartType = "oscillator",
+                // Overlay that REPLACES the raw price candles: the client
+                // hides the main price dataset while a candle-rendered overlay
+                // is displayed (both series sit at nearly the same prices, so
+                // drawing them together occludes each other) and restores it
+                // when the selection is removed.
+                ChartType = "overlay",
                 Results = [
                     new() {
                         DisplayName = "Heikin-Ashi",

--- a/web/src/components/picker/PickConfigDialog.spec.tsx
+++ b/web/src/components/picker/PickConfigDialog.spec.tsx
@@ -128,4 +128,38 @@ describe("PickConfigDialog", () => {
     expect(screen.getByLabelText("Line type")).toBeInTheDocument();
     expect(screen.getByLabelText("Line width")).toBeInTheDocument();
   });
+
+  it("hides the styles tab for candle-only listings (e.g. Heikin-Ashi)", () => {
+    // Candle series take colors from the themed candlestick element defaults,
+    // so per-result style controls would be no-ops.
+    const candleListing: IndicatorListing = {
+      ...listing,
+      name: "Heikin-Ashi",
+      uiid: "HEIKIN-ASHI",
+      category: "price-transform",
+      results: [
+        {
+          displayName: "Heikin-Ashi",
+          tooltipTemplate: "HEIKIN-ASHI",
+          dataName: "close",
+          dataType: "number",
+          lineType: "candle",
+          stack: "",
+          lineWidth: 2,
+          defaultColor: "#1E88E5"
+        }
+      ]
+    };
+    const controller = makeController();
+    render(
+      <PickConfigDialog
+        listing={candleListing}
+        controller={controller as unknown as ChartController}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("tab", { name: "Styles" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "ADD" })).toBeEnabled();
+  });
 });

--- a/web/src/components/picker/PickConfigDialog.tsx
+++ b/web/src/components/picker/PickConfigDialog.tsx
@@ -243,7 +243,13 @@ function usePickConfig(
   const [closeLabel, setCloseLabel] = useState("ADD");
 
   const hasParams = selection.params.length > 0;
-  const showStyles = listing.category !== "candlestick-pattern";
+  // Style controls are hidden where they'd be no-ops: candlestick-pattern
+  // markers and candle-rendered results (e.g. Heikin-Ashi) both take their
+  // colors from fixed pattern/theme rules, not per-result settings. The
+  // length guard keeps listings with no results (vacuous `every`) styleable.
+  const candleOnly =
+    listing.results.length > 0 && listing.results.every(r => r.lineType === "candle");
+  const showStyles = listing.category !== "candlestick-pattern" && !candleOnly;
   const [tab, setTab] = useState<TabId>(hasParams ? "params" : "styles");
 
   const formValid = useMemo(() => isFormValid(selection, showStyles), [selection, showStyles]);


### PR DESCRIPTION
Serves ToHeikinAshi() at HEIKIN-ASHI and lists it as a candle-rendered
pane using the new candle line type. It gets its own pane (oscillator
chart type) rather than overlaying the raw price candles, which sit at
nearly the same prices and would occlude both series. The picker hides
the no-op style controls for candle-only listings, whose colors come
from the themed candlestick element defaults.

Part of #498 (Renko intentionally excluded: bricks are not 1:1 with
quotes, which index-based window slicing requires).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>