### PR TITLE
chore: Bump indy-charts to 0.9.0 for publish

### DIFF
--- a/libs/indy-charts/package.json
+++ b/libs/indy-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@facioquo/indy-charts",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Framework-agnostic financial charting library with technical indicators and stock market data visualization",
   "author": "facioquo",
   "license": "Apache-2.0",


### PR DESCRIPTION
The merged candle-line-type and Heikin-Ashi work (#535, #536) triggered the publish workflow, but it skipped: `Version 0.8.0 already published`. This minor bump publishes the new backward-compatible features (candle line type for OHLC indicator results, price-candle hiding for replacing overlays) to GitHub Packages as **0.9.0**.