### PR TITLE
docs: Correct deploy-token scopes in the edge runbook

### DIFF
--- a/server/edge/README.md
+++ b/server/edge/README.md
@@ -126,9 +126,17 @@ pnpm --filter @stock-charts/edge exec wrangler secret put ALPACA_KEY
 pnpm --filter @stock-charts/edge exec wrangler secret put ALPACA_SECRET
 ```
 
-The `CLOUDFLARE_API_TOKEN` repository secret needs **Workers Scripts**, **Containers**, and **R2**
-edit permissions — broader than the Pages-only scope it previously required. `CLOUDFLARE_ACCOUNT_ID`
-is unchanged.
+The `CLOUDFLARE_API_TOKEN` repository secret needs these permissions (verified empirically on
+the first production deploy — each one gated a different step):
+
+- **Account** — Workers Scripts: Edit (script upload), Containers: Edit (container registration),
+  Cloudflare Pages: Edit (site deploy)
+- **Zone** (`stockindicators.dev`) — Workers Routes: Edit (the `charts-api` custom-domain route);
+  DNS: Edit is only needed if the custom-domain DNS record must be (re)provisioned
+
+R2 permissions are **not** required: the deploy only attaches the bucket binding as script
+metadata, and runtime access goes through the Worker's binding, never this token.
+`CLOUDFLARE_ACCOUNT_ID` is unchanged.
 
 Containers require the **Workers Paid** plan ($5/month minimum).
 


### PR DESCRIPTION
The runbook's token-permissions paragraph said **Workers Scripts, Containers, and R2** — written defensively before the first real deploy. The actual production deploy (run 31425497794) proved the real set empirically, with each permission gating a distinct failure we hit and fixed live:

- **Account:** Workers Scripts: Edit · Containers: Edit (`/containers/me` 403 without it) · Cloudflare Pages: Edit
- **Zone (`stockindicators.dev`):** Workers Routes: Edit (`/zones/…/workers/routes` 401 without it); DNS: Edit only for (re)provisioning the custom-domain record
- **R2: not needed** — binding attachment is script metadata; runtime access goes through the Worker binding

Docs-only change.