### PR TITLE
fix: Render candle indicators and unblock Pages preview CORS

### DIFF
--- a/libs/chartjs-financial/controllers/financial.controller.spec.ts
+++ b/libs/chartjs-financial/controllers/financial.controller.spec.ts
@@ -76,6 +76,19 @@ describe("FinancialController.getMinMax", () => {
     expect(minMax(parsed)).toEqual({ min: 99, max: 104 + 299 });
   });
 
+  it("ignores a bar with only one end non-finite", () => {
+    // `buildFinancialDataPoints` maps each OHLC field independently, so a row
+    // carrying a good low beside a null high produces a half-damaged bar. It
+    // draws no wick, so it must not stretch the axis from its good end either.
+    const parsed = [
+      bar(1, 100, 110, 95, 105),
+      { x: 2, o: 105, h: NaN, l: 1, c: 118 },
+      { x: 3, o: 105, h: 999, l: NaN, c: 118 }
+    ];
+
+    expect(minMax(parsed)).toEqual({ min: 95, max: 110 });
+  });
+
   it("ignores infinite lows and highs", () => {
     // Non-finite covers more than NaN: an infinity reaching the scale would
     // stretch the axis to nothing usable rather than merely blanking a bar.

--- a/libs/chartjs-financial/controllers/financial.controller.spec.ts
+++ b/libs/chartjs-financial/controllers/financial.controller.spec.ts
@@ -13,6 +13,9 @@ interface ParsedBar {
 const iScale = { axis: "x" as const };
 const vScale = {};
 
+/** What `getMinMax` returns when it has nothing to contribute to a scale. */
+const EMPTY_RANGE = { min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY };
+
 /**
  * `getMinMax` reads only `_cachedMeta`, so it can be exercised against a stub
  * rather than a live Chart.js instance and canvas.
@@ -64,11 +67,25 @@ describe("FinancialController.getMinMax", () => {
     expect(minMax(parsed)).toEqual({ min: 95, max: 120 });
   });
 
-  it("falls back to 0-1 when every bar is non-finite", () => {
-    expect(minMax([padding(1), padding(2), padding(3)])).toEqual({ min: 0, max: 1 });
+  it("claims no range when every bar is non-finite", () => {
+    // An inverted range is a no-op in the Math.min/Math.max fold Chart.js runs
+    // over the scale's datasets. A concrete 0-1 would read as real data on a
+    // price axis and would drag a co-plotted series' floor down to zero.
+    expect(minMax([padding(1), padding(2), padding(3)])).toEqual(EMPTY_RANGE);
   });
 
-  it("falls back to 0-1 when there is too little data", () => {
-    expect(minMax([bar(1, 100, 110, 95, 105)])).toEqual({ min: 0, max: 1 });
+  it("claims no range when there is no data at all", () => {
+    expect(minMax([])).toEqual(EMPTY_RANGE);
+  });
+
+  it("scales a lone bar to its own low/high", () => {
+    expect(minMax([bar(1, 100, 110, 95, 105)])).toEqual({ min: 95, max: 110 });
+  });
+
+  it("claims no index range below two bars", () => {
+    // Two points are needed to describe a span. On a time axis the old 0-1
+    // fallback meant 1 Jan 1970.
+    expect(minMax([bar(10, 100, 110, 95, 105)], iScale)).toEqual(EMPTY_RANGE);
+    expect(minMax([], iScale)).toEqual(EMPTY_RANGE);
   });
 });

--- a/libs/chartjs-financial/controllers/financial.controller.spec.ts
+++ b/libs/chartjs-financial/controllers/financial.controller.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { FinancialController } from "./financial.controller";
+
+interface ParsedBar {
+  x: number;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+}
+
+const iScale = { axis: "x" as const };
+const vScale = {};
+
+/**
+ * `getMinMax` reads only `_cachedMeta`, so it can be exercised against a stub
+ * rather than a live Chart.js instance and canvas.
+ */
+function minMax(parsed: ParsedBar[], scale: object = vScale): { min: number; max: number } {
+  const stub = {
+    _cachedMeta: { iScale, vScale, _parsed: parsed }
+  } as unknown as FinancialController;
+
+  return FinancialController.prototype.getMinMax.call(stub, scale);
+}
+
+function bar(x: number, o: number, h: number, l: number, c: number): ParsedBar {
+  return { x, o, h, l, c };
+}
+
+/** Trailing all-NaN padding, as emitted by indy-charts `addExtraFinancialBars`. */
+function padding(x: number): ParsedBar {
+  return { x, o: NaN, h: NaN, l: NaN, c: NaN };
+}
+
+describe("FinancialController.getMinMax", () => {
+  it("spans the low/high range of the value scale", () => {
+    expect(minMax([bar(1, 100, 110, 95, 105), bar(2, 105, 120, 102, 118)])).toEqual({
+      min: 95,
+      max: 120
+    });
+  });
+
+  it("returns first/last index values for the index scale", () => {
+    expect(minMax([bar(10, 100, 110, 95, 105), bar(20, 105, 120, 102, 118)], iScale)).toEqual({
+      min: 10,
+      max: 20
+    });
+  });
+
+  it("ignores trailing NaN padding bars", () => {
+    // Regression: a single NaN low or high used to poison Math.min/Math.max,
+    // leaving the scale unbounded so Chart.js fell back to 0-1 and clamped
+    // every candle off-canvas (facioquo/stock-indicators-dotnet#2183).
+    const parsed = [bar(1, 100, 110, 95, 105), bar(2, 105, 120, 102, 118), padding(3), padding(4)];
+
+    expect(minMax(parsed)).toEqual({ min: 95, max: 120 });
+  });
+
+  it("ignores NaN gaps in the middle of a series", () => {
+    const parsed = [bar(1, 100, 110, 95, 105), padding(2), bar(3, 105, 120, 102, 118)];
+
+    expect(minMax(parsed)).toEqual({ min: 95, max: 120 });
+  });
+
+  it("falls back to 0-1 when every bar is non-finite", () => {
+    expect(minMax([padding(1), padding(2), padding(3)])).toEqual({ min: 0, max: 1 });
+  });
+
+  it("falls back to 0-1 when there is too little data", () => {
+    expect(minMax([bar(1, 100, 110, 95, 105)])).toEqual({ min: 0, max: 1 });
+  });
+});

--- a/libs/chartjs-financial/controllers/financial.controller.spec.ts
+++ b/libs/chartjs-financial/controllers/financial.controller.spec.ts
@@ -76,6 +76,14 @@ describe("FinancialController.getMinMax", () => {
     expect(minMax(parsed)).toEqual({ min: 99, max: 104 + 299 });
   });
 
+  it("ignores infinite lows and highs", () => {
+    // Non-finite covers more than NaN: an infinity reaching the scale would
+    // stretch the axis to nothing usable rather than merely blanking a bar.
+    const parsed = [bar(1, 100, 110, 95, 105), bar(2, 105, Infinity, -Infinity, 118)];
+
+    expect(minMax(parsed)).toEqual({ min: 95, max: 110 });
+  });
+
   it("claims no range when every bar is non-finite", () => {
     // An inverted range is a no-op in the Math.min/Math.max fold Chart.js runs
     // over the scale's datasets. A concrete 0-1 would read as real data on a

--- a/libs/chartjs-financial/controllers/financial.controller.spec.ts
+++ b/libs/chartjs-financial/controllers/financial.controller.spec.ts
@@ -67,6 +67,15 @@ describe("FinancialController.getMinMax", () => {
     expect(minMax(parsed)).toEqual({ min: 95, max: 120 });
   });
 
+  it("scales a long series from its usable bars when one is unusable", () => {
+    // One bad bar out of 300 leaves a hole in place; the other 299 still
+    // define the range and still occupy their own slots.
+    const parsed = Array.from({ length: 300 }, (_, i) => bar(i, 100 + i, 104 + i, 99 + i, 103 + i));
+    parsed[150] = padding(150);
+
+    expect(minMax(parsed)).toEqual({ min: 99, max: 104 + 299 });
+  });
+
   it("claims no range when every bar is non-finite", () => {
     // An inverted range is a no-op in the Math.min/Math.max fold Chart.js runs
     // over the scale's datasets. A concrete 0-1 would read as real data on a

--- a/libs/chartjs-financial/controllers/financial.controller.ts
+++ b/libs/chartjs-financial/controllers/financial.controller.ts
@@ -176,14 +176,17 @@ export class FinancialController extends BarController {
     // keep them x-aligned with line/bar series that carry the same trailing
     // padding (see indy-charts `addExtraFinancialBars`), and gaps in real data
     // parse the same way.
+    //
+    // Both ends must be finite for a bar to count. A half-damaged bar draws no
+    // high-low wick, so letting its good end stretch the axis would reserve
+    // room for something that never appears.
     for (const point of parsed) {
-      if (Number.isFinite(point.l)) {
-        min = Math.min(min, point.l);
+      if (!Number.isFinite(point.l) || !Number.isFinite(point.h)) {
+        continue;
       }
 
-      if (Number.isFinite(point.h)) {
-        max = Math.max(max, point.h);
-      }
+      min = Math.min(min, point.l);
+      max = Math.max(max, point.h);
     }
 
     // Nothing finite leaves min/max as EMPTY_RANGE, which is exactly right:

--- a/libs/chartjs-financial/controllers/financial.controller.ts
+++ b/libs/chartjs-financial/controllers/financial.controller.ts
@@ -155,9 +155,27 @@ export class FinancialController extends BarController {
     let min = Number.POSITIVE_INFINITY;
     let max = Number.NEGATIVE_INFINITY;
 
+    // Skip non-finite bars. A single NaN low or high would otherwise poison
+    // the whole reduction — `Math.min(x, NaN)` is NaN — leaving the value
+    // scale with no usable bounds, so Chart.js falls back to 0-1 and clamps
+    // every candle off-canvas. Callers legitimately pad OHLC series with
+    // all-NaN bars to keep them x-aligned with line/bar series that carry the
+    // same trailing padding (see indy-charts `addExtraFinancialBars`), and
+    // gaps in real data parse the same way.
     for (const point of parsed) {
-      min = Math.min(min, point.l);
-      max = Math.max(max, point.h);
+      if (Number.isFinite(point.l)) {
+        min = Math.min(min, point.l);
+      }
+
+      if (Number.isFinite(point.h)) {
+        max = Math.max(max, point.h);
+      }
+    }
+
+    // Every bar was non-finite; match the too-little-data branch above rather
+    // than handing the scale ±Infinity.
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      return { min: 0, max: 1 };
     }
 
     return { min, max };

--- a/libs/chartjs-financial/controllers/financial.controller.ts
+++ b/libs/chartjs-financial/controllers/financial.controller.ts
@@ -85,6 +85,21 @@ interface Ruler {
   ratio: number;
 }
 
+/**
+ * The "no data to contribute" range for {@link FinancialController.getMinMax}.
+ *
+ * Chart.js seeds `Scale.getMinMax` with these same values and folds every
+ * dataset in with `Math.min`/`Math.max`, so an inverted range is a no-op:
+ * sibling datasets keep their own bounds instead of being widened. Returning a
+ * concrete span here — 0-1, say — would instead be a claim that the series
+ * holds values in that range, which reads as real data on a price axis and
+ * drags any co-plotted series' floor down with it.
+ *
+ * When nothing at all is on the scale, Chart.js applies its own empty-scale
+ * default; that is the framework's call to make, not this controller's.
+ */
+const EMPTY_RANGE = { min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY };
+
 export class FinancialController extends BarController {
   static overrides = {
     label: "",
@@ -144,12 +159,11 @@ export class FinancialController extends BarController {
     const parsed = controller._cachedMeta._parsed;
     const axis = controller._cachedMeta.iScale.axis;
 
-    if (parsed.length < 2) {
-      return { min: 0, max: 1 };
-    }
-
     if (scale === controller._cachedMeta.iScale) {
-      return { min: parsed[0][axis] ?? 0, max: parsed[parsed.length - 1][axis] ?? 0 };
+      // Fewer than two bars cannot describe a span, so claim no range at all.
+      return parsed.length < 2
+        ? EMPTY_RANGE
+        : { min: parsed[0][axis] ?? 0, max: parsed[parsed.length - 1][axis] ?? 0 };
     }
 
     let min = Number.POSITIVE_INFINITY;
@@ -157,11 +171,11 @@ export class FinancialController extends BarController {
 
     // Skip non-finite bars. A single NaN low or high would otherwise poison
     // the whole reduction — `Math.min(x, NaN)` is NaN — leaving the value
-    // scale with no usable bounds, so Chart.js falls back to 0-1 and clamps
-    // every candle off-canvas. Callers legitimately pad OHLC series with
-    // all-NaN bars to keep them x-aligned with line/bar series that carry the
-    // same trailing padding (see indy-charts `addExtraFinancialBars`), and
-    // gaps in real data parse the same way.
+    // scale with no usable bounds, so Chart.js clamped every candle
+    // off-canvas. Callers legitimately pad OHLC series with all-NaN bars to
+    // keep them x-aligned with line/bar series that carry the same trailing
+    // padding (see indy-charts `addExtraFinancialBars`), and gaps in real data
+    // parse the same way.
     for (const point of parsed) {
       if (Number.isFinite(point.l)) {
         min = Math.min(min, point.l);
@@ -172,12 +186,8 @@ export class FinancialController extends BarController {
       }
     }
 
-    // Every bar was non-finite; match the too-little-data branch above rather
-    // than handing the scale ±Infinity.
-    if (!Number.isFinite(min) || !Number.isFinite(max)) {
-      return { min: 0, max: 1 };
-    }
-
+    // Nothing finite leaves min/max as EMPTY_RANGE, which is exactly right:
+    // damaged or absent bars are simply not drawn and contribute no bounds.
     return { min, max };
   }
 

--- a/libs/chartjs-financial/package.json
+++ b/libs/chartjs-financial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@facioquo/chartjs-chart-financial",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Financial charting extension for Chart.js (candlestick, OHLC, volume charts)",
   "author": "facioquo",
   "license": "Apache-2.0",

--- a/libs/indy-charts/charts/overlay-chart.spec.ts
+++ b/libs/indy-charts/charts/overlay-chart.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { OverlayChart } from "./overlay-chart";
+import { type ChartSettings } from "../config/types";
+
+const settings: ChartSettings = { isDarkTheme: true, showTooltips: false };
+
+interface StubDataset {
+  label: string;
+  type: string;
+  hidden?: boolean;
+}
+
+/**
+ * `setPriceVisibility` reaches only into `_chart.data.datasets`, so a stub
+ * stands in for a live Chart.js instance and canvas.
+ */
+function withDatasets(datasets: StubDataset[]): {
+  overlay: OverlayChart;
+  update: ReturnType<typeof vi.fn>;
+} {
+  const update = vi.fn();
+  const overlay = new OverlayChart({} as CanvasRenderingContext2D, settings);
+  (overlay as unknown as { _chart: unknown })._chart = { data: { datasets }, update };
+  return { overlay, update };
+}
+
+/** The overlay's fixed dataset order: price candles first, volume second. */
+function priceAndVolume(): StubDataset[] {
+  return [
+    { label: "Price", type: "candlestick" },
+    { label: "Volume", type: "bar" }
+  ];
+}
+
+describe("OverlayChart.setPriceVisibility", () => {
+  it("hides the raw price candles without touching volume", () => {
+    // A candle-rendered indicator (e.g. Heikin-Ashi) replaces the price candles
+    // because both sit at nearly the same prices. Volume is a separate series
+    // on its own axis and must keep rendering either way.
+    const datasets = priceAndVolume();
+    const { overlay, update } = withDatasets(datasets);
+
+    overlay.setPriceVisibility(false);
+
+    expect(datasets[0].hidden).toBe(true);
+    expect(datasets[1].hidden).toBeUndefined();
+    expect(update).toHaveBeenCalledWith("none");
+  });
+
+  it("restores the price candles when the candle overlay goes away", () => {
+    const datasets = priceAndVolume();
+    datasets[0].hidden = true;
+    const { overlay } = withDatasets(datasets);
+
+    overlay.setPriceVisibility(true);
+
+    expect(datasets[0].hidden).toBe(false);
+    expect(datasets[1].hidden).toBeUndefined();
+  });
+
+  it("leaves the datasets alone when the first one is not the price candles", () => {
+    const datasets: StubDataset[] = [{ label: "Volume", type: "bar" }];
+    const { overlay, update } = withDatasets(datasets);
+
+    overlay.setPriceVisibility(false);
+
+    expect(datasets[0].hidden).toBeUndefined();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("no-ops before the chart is rendered", () => {
+    const overlay = new OverlayChart({} as CanvasRenderingContext2D, settings);
+
+    expect(() => overlay.setPriceVisibility(false)).not.toThrow();
+  });
+});

--- a/libs/indy-charts/data/transformers.spec.ts
+++ b/libs/indy-charts/data/transformers.spec.ts
@@ -730,6 +730,46 @@ describe("buildFinancialDataPoints", () => {
     expect(points[1].c).toBe(103);
   });
 
+  it("treats explicit null OHLC as a gap, the same as a missing field", () => {
+    // The .NET API emits null (not a missing key, and never NaN) for warmup and
+    // unavailable periods, so nulls arrive here in normal operation.
+    const rows: IndicatorDataRow[] = [
+      { timestamp: "2024-01-02", open: null, high: null, low: null, close: null },
+      { timestamp: "2024-01-03", open: 101, high: 104, low: 99, close: 103 }
+    ];
+
+    const points = buildFinancialDataPoints(rows, result);
+
+    expect(points).toHaveLength(2);
+    expect(points[0].l).toBeNaN();
+    expect(points[1].l).toBe(99);
+  });
+
+  it("keeps every slot when a single bar in a long series is unusable", () => {
+    // One bad bar leaves a hole in place; it must not drop the slot and shift
+    // every later bar left. Positions come from each row's own timestamp, so
+    // the surrounding bars stay exactly where they were.
+    const rows: IndicatorDataRow[] = Array.from({ length: 300 }, (_, i) => ({
+      timestamp: new Date(Date.UTC(2024, 0, 1) + i * 86_400_000).toISOString(),
+      open: 100 + i,
+      high: 104 + i,
+      low: 99 + i,
+      close: 103 + i
+    }));
+    const holed = rows[150];
+    rows[150] = { timestamp: holed.timestamp, open: null, high: null, low: null, close: null };
+
+    const points = buildFinancialDataPoints(rows, result);
+
+    expect(points).toHaveLength(300);
+    expect(points[150].l).toBeNaN();
+    expect(points.filter(p => Number.isNaN(p.l))).toHaveLength(1);
+    // Neighbours keep their own values, and every slot keeps its own x.
+    expect(points[149].l).toBe(99 + 149);
+    expect(points[151].l).toBe(99 + 151);
+    expect(points.map(p => p.x)).toEqual(rows.map(r => new Date(r.timestamp as string).valueOf()));
+  });
+
   it("throws when a row is missing its timestamp", () => {
     const rows: IndicatorDataRow[] = [{ open: 101, high: 104, low: 99, close: 103 }];
 

--- a/libs/indy-charts/package.json
+++ b/libs/indy-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@facioquo/indy-charts",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Framework-agnostic financial charting library with technical indicators and stock market data visualization",
   "author": "facioquo",
   "license": "Apache-2.0",

--- a/server/edge/src/cors.spec.ts
+++ b/server/edge/src/cors.spec.ts
@@ -1,4 +1,6 @@
 import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -14,7 +16,10 @@ const ALLOW_LIST =
  * throws here, which is the intent.
  */
 function deployedAllowList(): string {
-  const config = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+  // Path built as a string: this package compiles against Workers types, where
+  // the global URL is not Node's and so is not a valid readFileSync argument.
+  const configPath = join(dirname(fileURLToPath(import.meta.url)), "..", "wrangler.jsonc");
+  const config = readFileSync(configPath, "utf8");
   const match = /"ALLOWED_ORIGINS":\s*"([^"]+)"/.exec(config);
 
   if (match === null) {

--- a/server/edge/src/cors.spec.ts
+++ b/server/edge/src/cors.spec.ts
@@ -1,9 +1,28 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import { applyCors, preflightResponse, resolveAllowedOrigin, stripCors } from "./cors";
 
 const ALLOW_LIST =
   "https://charts.stockindicators.dev,https://stock-charts-vitepress.pages.dev,https://*.preview.pages.dev";
+
+/**
+ * The list the Worker actually deploys with. Read straight out of
+ * wrangler.jsonc: JSON.parse would choke on the comments, and the value is a
+ * single flat string, so a targeted match is enough. A rename or restructure
+ * throws here, which is the intent.
+ */
+function deployedAllowList(): string {
+  const config = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+  const match = /"ALLOWED_ORIGINS":\s*"([^"]+)"/.exec(config);
+
+  if (match === null) {
+    throw new Error("ALLOWED_ORIGINS not found in wrangler.jsonc");
+  }
+
+  return match[1];
+}
 
 describe("resolveAllowedOrigin", () => {
   it("echoes an exactly listed origin", () => {
@@ -36,6 +55,42 @@ describe("resolveAllowedOrigin", () => {
 
   it("returns null for a malformed Origin instead of throwing", () => {
     expect(resolveAllowedOrigin("not-a-url", ALLOW_LIST)).toBeNull();
+  });
+});
+
+// The cases above use a synthetic list to exercise the matcher. These run the
+// matcher against the list the Worker actually ships, so an edit to that
+// comma-separated string cannot silently drop coverage for a live site.
+describe("deployed ALLOWED_ORIGINS", () => {
+  const deployed = deployedAllowList();
+
+  it.each([
+    ["production docs", "https://dotnet.stockindicators.dev"],
+    ["production demo", "https://charts.stockindicators.dev"],
+    ["docs Pages default domain", "https://stock-indicators-dotnet-76p.pages.dev"],
+    ["demo Pages default domain", "https://stock-charts.pages.dev"],
+    // Preview hostnames are generated per branch and per deployment, so these
+    // stand in for an ever-changing set the list can only match by suffix.
+    ["docs preview by branch", "https://some-branch.stock-indicators-dotnet-76p.pages.dev"],
+    ["docs preview by hash", "https://a1b2c3d4.stock-indicators-dotnet-76p.pages.dev"],
+    ["demo preview", "https://some-branch.stock-charts.pages.dev"],
+    ["vitepress demo preview", "https://some-branch.stock-charts-vitepress.pages.dev"]
+  ])("allows the %s origin", (_label, origin) => {
+    expect(resolveAllowedOrigin(origin, deployed)).toBe(origin);
+  });
+
+  it.each([
+    ["an unrelated Pages site", "https://evil.pages.dev"],
+    ["a suffix-spoofing host", "https://stock-indicators-dotnet-76p.pages.dev.evil.example"],
+    ["a prefix-spoofing host", "https://notstock-indicators-dotnet-76p.pages.dev"],
+    ["a scheme downgrade", "http://some-branch.stock-indicators-dotnet-76p.pages.dev"]
+  ])("rejects %s", (_label, origin) => {
+    expect(resolveAllowedOrigin(origin, deployed)).toBeNull();
+  });
+
+  it("stays scoped to known projects rather than all of pages.dev", () => {
+    expect(deployed).not.toContain("https://*.pages.dev,");
+    expect(deployed.endsWith("https://*.pages.dev")).toBe(false);
   });
 });
 

--- a/server/edge/wrangler.jsonc
+++ b/server/edge/wrangler.jsonc
@@ -81,7 +81,25 @@
     // Origins allowed to call the API cross-site. The Worker answers preflight
     // and rewrites Access-Control-* itself, so this is the production source of
     // truth; server/WebApi/appsettings.json only covers direct/local hosting.
-    "ALLOWED_ORIGINS": "https://charts.stockindicators.dev,https://dotnet.stockindicators.dev,https://stock-charts.pages.dev,https://stock-charts-vitepress.pages.dev",
+    //
+    // Three kinds of entry, in order below:
+    //   1. Production custom domains.
+    //   2. Pages project default domains (`<project>.pages.dev`), which serve
+    //      the production branch. Cloudflare assigns these and may append a
+    //      suffix on name collision — hence `stock-indicators-dotnet-76p`.
+    //   3. `*.` wildcards for Cloudflare Pages preview deployments. Preview
+    //      hostnames are generated per branch and per deployment
+    //      (`<branch-slug>.<project>.pages.dev`, `<hash>.<project>.pages.dev`)
+    //      and change constantly, so they can only be matched by suffix — a
+    //      literal entry would be stale by the next push. The project apex is
+    //      the stable part. Without these, every chart on a PR preview fails
+    //      its fetch on CORS (facioquo/stock-indicators-dotnet#2183).
+    //
+    // The wildcard is deliberately anchored to each project rather than a
+    // blanket `https://*.pages.dev`, which would open the API to any site
+    // hosted on Cloudflare Pages. `resolveAllowedOrigin` never matches a `*.`
+    // entry against its own bare apex, so both forms are listed.
+    "ALLOWED_ORIGINS": "https://charts.stockindicators.dev,https://dotnet.stockindicators.dev,https://stock-charts.pages.dev,https://stock-charts-vitepress.pages.dev,https://stock-indicators-dotnet-76p.pages.dev,https://*.stock-charts.pages.dev,https://*.stock-charts-vitepress.pages.dev,https://*.stock-indicators-dotnet-76p.pages.dev",
     // The deployed Worker's own origin. Passed through to the container as
     // Api__PublicBaseUrl (see src/container.ts) so the /indicators catalog
     // embeds externally-reachable URLs instead of the container's internal


### PR DESCRIPTION
Two independent defects, both surfaced while wiring charts onto the docs site in facioquo/stock-indicators-dotnet#2183.

## 1. Candle-rendered indicators render nothing

`FinancialController.getMinMax()` folded every parsed bar into `Math.min`/`Math.max` with no finite check. `Math.min(x, NaN)` is `NaN`, so **one** non-finite bar left the value scale with no usable bounds — Chart.js fell back to `0–1` and clamped every candle off-canvas at `-32768`.

indy-charts pads candle datasets with trailing all-NaN bars on purpose (`addExtraFinancialBars`) so they stay x-aligned with the line/bar series carrying the same padding. That meant **every** `lineType: "candle"` indicator hit this. The raw price series escaped only because it is never padded. Gaps in real OHLC data parse the same way and would have hit it too.

Observed on `/indicators/heikin-ashi`: the overlay chart drew volume bars and nothing else. It failed worse than a missing chart, because a candle overlay also hides the raw price candles — so the page lost the price series too.

Diagnosis, on the live 0.9.0 bundle:

| dataset | visible | parsed points | `getMinMax(y)` |
|---|---|---|---|
| `Price` (unpadded) | hidden by the overlay | 120 | `{min: 555.6, max: 748.43}` |
| `HEIKIN-ASHI` (padded) | yes | 126 | `{min: null, max: null}` |

…with scale `y` at `{min: 0, max: 1}`.

**Fix:** skip non-finite lows/highs, and claim no range at all when nothing is finite.

Damaged or absent bars are simply not drawn and contribute no bounds. The "no range" signal is an inverted range — the same values Chart.js seeds `Scale.getMinMax` with before folding each dataset in via `Math.min`/`Math.max` — so an empty series is a no-op and sibling datasets keep their own bounds.

This also removes the pre-existing `0–1` fallbacks, which were wrong in the same way the bug was:

- `0–1` is a plausible price range, so an empty chart looked like it held real data
- worse, because of that `Math.min`/`Math.max` fold, one empty candle series beside a populated one dragged the whole scale's floor to zero — a chart spanning 555–748 would have been squashed into the top of the plot
- on a time axis, `0–1` meant 1 Jan 1970

The blanket "fewer than two bars" short-circuit is now scoped to the index-scale branch, which is the only part that needs two points to describe a span. A lone bar scales to its own low/high instead of vanishing off a `0–1` axis. When nothing at all is on a scale, Chart.js applies its own empty-scale default — the framework's call, not this controller's.

**Verified:** injecting the equivalent guard into the shipped 0.9.0 bundle at request time renders the Heikin-Ashi candles correctly, price still hidden as designed. Nine unit tests in `financial.controller.spec.ts` pin the contract, including the padded-series case that browser run exercised; the regression cases fail without the fix and pass with it.

Both packages are bumped so the fixed bundle publishes — `@facioquo/chartjs-chart-financial` 0.1.1 → 0.1.2, `@facioquo/indy-charts` 0.9.0 → 0.9.1. `web` and `tests/vitepress` consume via `workspace:*`, so nothing else needs a bump.

## 2. Charts blocked by CORS on every Pages preview

`ALLOWED_ORIGINS` listed only the production custom domains and the project apexes, so the Worker returned no `Access-Control-Allow-Origin` for a preview origin and the browser blocked every chart fetch.

```
https://dotnet.stockindicators.dev                    → echoed ✅
https://<branch>.stock-indicators-dotnet-76p.pages.dev → none ❌
```

Preview hostnames are generated per branch **and** per deployment (`<branch-slug>.<project>.pages.dev`, `<hash>.<project>.pages.dev`) and change on every push, so they can only be matched by suffix — a literal entry would be stale immediately. `resolveAllowedOrigin` already supports leading `*.` wildcards; this just uses them. The project apex is the stable part (Cloudflare appends a collision suffix, hence `stock-indicators-dotnet-76p`).

Added, covering all three Pages projects:

- `https://*.stock-charts.pages.dev`
- `https://*.stock-charts-vitepress.pages.dev`
- `https://stock-indicators-dotnet-76p.pages.dev` and `https://*.stock-indicators-dotnet-76p.pages.dev`

Anchored per project rather than a blanket `https://*.pages.dev`, which would open the API to any site hosted on Cloudflare Pages. The apex entries stay because a `*.` entry deliberately never matches its own bare apex.

**Verified** against the real `resolveAllowedOrigin` with the actual config value: the branch alias, deployment hash, and apex all resolve, while `https://evil.pages.dev`, `https://stock-indicators-dotnet-76p.pages.dev.evil.com`, `http://` scheme downgrade, and `https://notstock-indicators-dotnet-76p.pages.dev` all still return `null`.

This is a Worker var, so it needs an edge deploy to take effect — merging alone will not fix existing previews.

## Review follow-ups

- **CodeRabbit** — added `Infinity`/`-Infinity` coverage, so the tests exercise the whole `Number.isFinite` contract rather than just `NaN`.
- **Mage, half-damaged bars** — confirmed reachable: `buildFinancialDataPoints` maps each OHLC field independently, so a row with a good low beside a null high produces a bar with one finite end. It draws no wick, so letting its good end stretch the axis reserved room for something that never appears — the same false impression as the `0–1` fallback, just narrower. Both ends must now be finite for a bar to count.
- **Mage, untested allow-list** — `cors.spec.ts` now runs the matcher against the `ALLOWED_ORIGINS` string the Worker actually deploys with, read out of `wrangler.jsonc`, covering all four live origins plus the two preview shapes and four rejection cases. Confirmed the new cases fail when the wildcard entries are removed.

Also pinned two behaviours this change depends on but that had no coverage: a candle overlay hides only the price candles and leaves the volume series alone, and one bad bar in a 300-bar series leaves a hole in place rather than dropping the slot and shifting everything after it.

## Checks

- `pnpm run test:libs` — 22/22 chartjs-financial, 232/232 indy-charts
- `pnpm --filter @stock-charts/edge run test` — 42/42
- `pnpm --filter @facioquo/indy-charts run build` clean; guard confirmed present in the emitted bundle
- lint, `format:check`, and `tsc` clean on the touched package

## Follow-up

Once 0.9.1 publishes, facioquo/stock-indicators-dotnet#2183 can bump to `^0.9.1` and revert its `4800c1a8`, which pulled the Heikin-Ashi chart off the docs page.
